### PR TITLE
Put loader/firmware header into image

### DIFF
--- a/Makefile.firmware
+++ b/Makefile.firmware
@@ -311,6 +311,7 @@ OBJ_HAL += $(addprefix $(BUILD_MP)/,\
 
 # OBJ micropython/
 OBJ_FW += $(addprefix $(BUILD_FW)/, \
+	firmware/header.o \
 	firmware/main.o \
 	firmware/mphalport.o \
 	trezorhal/common.o \

--- a/Makefile.loader
+++ b/Makefile.loader
@@ -56,6 +56,7 @@ OBJ_HAL += $(addprefix $(BUILD_MP)/,\
 
 # OBJ micropython/
 OBJ_FW += $(addprefix $(BUILD_FW)/, \
+	loader/header.o \
 	loader/main.o \
 	extmod/modtrezorui/display.o \
 	extmod/modtrezorui/font_bitmap.o \

--- a/micropython/bootloader/main.c
+++ b/micropython/bootloader/main.c
@@ -131,7 +131,7 @@ int main(void)
     BOOTLOADER_PRINTLN("waiting 1 second");
     HAL_Delay(1000);
     BOOTLOADER_PRINTLN("jumping to loader");
-    jump_to(LOADER_START);
+    jump_to(LOADER_START + HEADER_SIZE);
     // end
 
     if (check_sdcard()) {
@@ -146,7 +146,7 @@ int main(void)
         if (check_signature((const uint8_t *)LOADER_START)) {
             BOOTLOADER_PRINTLN("valid loader signature");
             BOOTLOADER_PRINTLN("JUMP!");
-            jump_to(LOADER_START + 256);
+            jump_to(LOADER_START + HEADER_SIZE);
         } else {
             BOOTLOADER_PRINTLN("invalid loader signature");
         }

--- a/micropython/firmware/header.S
+++ b/micropython/firmware/header.S
@@ -1,0 +1,20 @@
+#include "version.h"
+
+	.section  .header,"a",%progbits
+
+	.type g_header, %object
+	.size g_header, .-g_header
+
+g_header:
+	.byte 'T','R','Z','F'
+	.word g_header_end - g_header
+	.word 0   /* valid until */
+	.word _codelen
+	.byte VERSION_MAJOR
+	.byte VERSION_MINOR
+	.byte VERSION_PATCH
+	.byte VERSION_BUILD
+	. = . + 427 /* reserved */
+	.byte 0    /* sigindex */
+	. = . + 64 /* signatures */
+g_header_end:

--- a/micropython/firmware/main.c
+++ b/micropython/firmware/main.c
@@ -24,7 +24,7 @@
 
 int main(void) {
 
-    SCB->VTOR = FIRMWARE_START;
+    SCB->VTOR = FIRMWARE_START + HEADER_SIZE;
     periph_init();
 
     pendsv_init();

--- a/micropython/firmware/memory.ld
+++ b/micropython/firmware/memory.ld
@@ -29,6 +29,7 @@ SECTIONS
     .flash :
     {
         . = ALIGN(4);
+        KEEP(*(.header))     /* Firmware Header */
         KEEP(*(.isr_vector)) /* Startup code */
         . = ALIGN(4);
         *(.text*)          /* .text* sections (code) */
@@ -86,6 +87,7 @@ SECTIONS
 }
 
 /* RAM extents for the garbage collector */
+_codelen = SIZEOF(.flash) + SIZEOF(.data);
 _ram_start = ORIGIN(RAM);
 _ram_end = ORIGIN(RAM) + LENGTH(RAM);
 _heap_start = _ebss; /* heap starts just after statically allocated memory */

--- a/micropython/firmware/version.h
+++ b/micropython/firmware/version.h
@@ -1,0 +1,4 @@
+#define VERSION_MAJOR 0
+#define VERSION_MINOR 1
+#define VERSION_PATCH 0
+#define VERSION_BUILD 0

--- a/micropython/loader/header.S
+++ b/micropython/loader/header.S
@@ -1,0 +1,20 @@
+#include "version.h"
+
+	.section  .header,"a",%progbits
+
+	.type g_header, %object
+	.size g_header, .-g_header
+
+g_header:
+	.byte 'T','R','Z','L'
+	.word g_header_end - g_header
+	.word 0   /* valid until */
+	.word _codelen
+	.byte VERSION_MAJOR
+	.byte VERSION_MINOR
+	.byte VERSION_PATCH
+	.byte VERSION_BUILD
+	. = . + 427 /* reserved */
+	.byte 0    /* sigindex */
+	. = . + 64 /* signatures */
+g_header_end:

--- a/micropython/loader/main.c
+++ b/micropython/loader/main.c
@@ -15,7 +15,7 @@ void pendsv_isr_handler(void) {
 
 int main(void)
 {
-    SCB->VTOR = LOADER_START;
+    SCB->VTOR = LOADER_START + HEADER_SIZE;
     periph_init();
 
     display_init();
@@ -27,7 +27,7 @@ int main(void)
     HAL_Delay(1000);
     LOADER_PRINTLN("jumping to firmware");
 
-    jump_to(FIRMWARE_START);
+    jump_to(FIRMWARE_START + HEADER_SIZE);
 
     return 0;
 }

--- a/micropython/loader/memory.ld
+++ b/micropython/loader/memory.ld
@@ -29,6 +29,7 @@ SECTIONS
     .flash :
     {
         . = ALIGN(4);
+	KEEP(*(.header))
         KEEP(*(.isr_vector)) /* Startup code */
         . = ALIGN(4);
         *(.text*)          /* .text* sections (code) */
@@ -52,6 +53,7 @@ SECTIONS
 
         . = ALIGN(4);
         _edata = .;        /* define a global symbol at data end; used by startup code in order to initialise the .data section in RAM */
+	_datalen = . - _sdata;
     } >RAM AT> FLASH
 
     /* Uninitialized data section */
@@ -86,6 +88,7 @@ SECTIONS
 }
 
 /* RAM extents for the garbage collector */
+_codelen = SIZEOF(.flash) + SIZEOF(.data);
 _ram_start = ORIGIN(RAM);
 _ram_end = ORIGIN(RAM) + LENGTH(RAM);
 _heap_start = _ebss; /* heap starts just after statically allocated memory */

--- a/micropython/loader/version.h
+++ b/micropython/loader/version.h
@@ -1,0 +1,4 @@
+#define VERSION_MAJOR 0
+#define VERSION_MINOR 1
+#define VERSION_PATCH 0
+#define VERSION_BUILD 0

--- a/micropython/trezorhal/common.h
+++ b/micropython/trezorhal/common.h
@@ -6,6 +6,7 @@
 #define BOOTLOADER_START  0x08000000
 #define LOADER_START      0x08010000
 #define FIRMWARE_START    0x08020000
+#define HEADER_SIZE       0x200
 
 void periph_init(void);
 


### PR DESCRIPTION
Put the 512 byte loader and firmware header into the image.
Fix the addresses of the vector table.