### PR TITLE
better support ILI9341 testing, make tearing effect synch optional, minor fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,14 @@ UNIX_PORT_OPTS ?= TREZOR_X86=1
 endif
 CROSS_PORT_OPTS ?= MICROPY_FORCE_32BIT=1
 
+ifeq ($(DISPLAY_ILI9341V), 1)
+CFLAGS += -DDISPLAY_ILI9341V=1
+CFLAGS += -DDISPLAY_ST7789V=0
+endif
+
+ifeq ($(DISPLAY_VSYNC), 0)
+CFLAGS += -DDISPLAY_VSYNC=0
+endif
 
 ## help commands:
 
@@ -57,13 +65,13 @@ style: ## run code style check on application sources
 build: build_boardloader build_bootloader build_firmware build_unix build_cross ## build all
 
 build_boardloader: ## build boardloader
-	$(SCONS) build/boardloader/boardloader.bin
+	$(SCONS) CFLAGS="$(CFLAGS)" build/boardloader/boardloader.bin
 
 build_bootloader: ## build bootloader
-	$(SCONS) build/bootloader/bootloader.bin
+	$(SCONS) CFLAGS="$(CFLAGS)" build/bootloader/bootloader.bin
 
 build_firmware: res build_cross ## build firmware with frozen modules
-	$(SCONS) build/firmware/firmware.bin
+	$(SCONS) CFLAGS="$(CFLAGS)" build/firmware/firmware.bin
 
 build_unix: ## build unix port
 	$(SCONS) build/unix/micropython $(UNIX_PORT_OPTS)

--- a/SConscript.boardloader
+++ b/SConscript.boardloader
@@ -84,7 +84,7 @@ SOURCE_TREZORHAL = [
     'embed/trezorhal/stm32_system.c',
 ]
 
-env = Environment(ENV=os.environ)
+env = Environment(ENV=os.environ, CFLAGS=ARGUMENTS.get('CFLAGS', ''))
 
 env.Replace(
     AS='arm-none-eabi-as',

--- a/SConscript.bootloader
+++ b/SConscript.bootloader
@@ -102,7 +102,7 @@ SOURCE_TREZORHAL = [
     'embed/trezorhal/usbd_ioreq.c',
 ]
 
-env = Environment(ENV=os.environ)
+env = Environment(ENV=os.environ, CFLAGS=ARGUMENTS.get('CFLAGS', ''))
 
 env.Replace(
     AS='arm-none-eabi-as',

--- a/SConscript.firmware
+++ b/SConscript.firmware
@@ -299,7 +299,7 @@ SOURCE_PY.extend(Glob('src/*/*/*/*.py'))
 SOURCE_PY.extend(Glob('src/*/*/*/*/*.py'))
 SOURCE_PY_DIR = 'src/'
 
-env = Environment(ENV=os.environ)
+env = Environment(ENV=os.environ, CFLAGS=ARGUMENTS.get('CFLAGS', ''))
 
 env.Tool('micropython')
 

--- a/embed/extmod/modtrezorui/display.h
+++ b/embed/extmod/modtrezorui/display.h
@@ -10,6 +10,10 @@
 
 #include <stdint.h>
 
+// ILI9341V and ST7789V drivers both support 240px x 320px display resolution
+#define MAX_DISPLAY_RESX 240
+#define MAX_DISPLAY_RESY 320
+// X and Y display resolution used
 #define DISPLAY_RESX 240
 #define DISPLAY_RESY 240
 

--- a/embed/trezorhal/common.c
+++ b/embed/trezorhal/common.c
@@ -5,6 +5,8 @@
 
 void __attribute__((noreturn)) __fatal_error(const char *msg, const char *file, int line, const char *func) {
     for (volatile uint32_t delay = 0; delay < 10000000; delay++) {}
+    display_orientation(0);
+    display_backlight(255);
     display_print_color(COLOR_WHITE, COLOR_RED128);
     display_printf("\nFATAL ERROR:\n%s\n", msg);
     if (file) {
@@ -13,12 +15,7 @@ void __attribute__((noreturn)) __fatal_error(const char *msg, const char *file, 
     if (func) {
         display_printf("Func: %s\n", func);
     }
-    for (;;) {
-        display_backlight(255);
-        HAL_Delay(950);
-        display_backlight(128);
-        HAL_Delay(50);
-    }
+    for (;;);
 }
 
 #ifndef NDEBUG


### PR DESCRIPTION
My current test display is ILI9341 and doesn't have the tearing effect line connected.
The build changes scratch that itch while defaulting to what you had already.
Example usage:
`make build_boardloader TEARING_EFFECT=1 DISPLAY_ILI9341V=1`

I removed the red flash on fatal error to avoid possibly triggering epileptic seizures for people.

Code review question:
Does the ST7789V really use RGB while the ILI9341V uses BGR? I tested with the ILI9341 and BGR works for it. I don't have my ST7789V display yet.
