### PR TITLE
display related updates, flashing++

### DIFF
--- a/embed/boardloader/main.c
+++ b/embed/boardloader/main.c
@@ -146,9 +146,6 @@ int main(void)
         __fatal_error("sdcard_init", __FILE__, __LINE__, __FUNCTION__);
     }
 
-    display_clear();
-    display_backlight(255);
-
     display_printf("TREZOR Boardloader %d.%d.%d.%d\n", VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH, VERSION_BUILD);
     display_printf("==================\n");
     display_printf("starting boardloader\n");

--- a/embed/bootloader/main.c
+++ b/embed/bootloader/main.c
@@ -83,7 +83,6 @@ void check_and_jump(void)
 
         display_vendor(vhdr.vimg, (const char *)vhdr.vstr, vhdr.vstr_len, hdr.version);
         HAL_Delay(1000); // TODO: remove?
-        display_printf("JUMP!\n");
         jump_to(FIRMWARE_START + vhdr.hdrlen + HEADER_SIZE);
 
     } else {
@@ -195,16 +194,13 @@ int main(void)
 {
     periph_init();
 
-    if (0 != display_init()) {
-        __fatal_error("display_init", __FILE__, __LINE__, __FUNCTION__);
-    }
+    display_pwm_init();
+    display_orientation(0);
+    display_backlight(255);
 
     if (0 != touch_init()) {
         __fatal_error("touch_init", __FILE__, __LINE__, __FUNCTION__);
     }
-
-    display_clear();
-    display_backlight(255);
 
     display_printf("TREZOR Bootloader %d.%d.%d.%d\n", VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH, VERSION_BUILD);
     display_printf("=================\n");

--- a/embed/extmod/modtrezorui/display-unix.h
+++ b/embed/extmod/modtrezorui/display-unix.h
@@ -62,7 +62,7 @@ int display_init(void)
     return 0;
 }
 
-static void display_set_window(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1)
+static void display_set_window_raw(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1)
 {
 #ifndef TREZOR_NOUI
     SX = x0; SY = y0;
@@ -70,6 +70,11 @@ static void display_set_window(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y
     POSX = SX; POSY = SY;
     DATAODD = 0;
 #endif
+}
+
+static void display_set_window(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1)
+{
+    display_set_window_raw(x0, y0, x1, y1);
 }
 
 void display_refresh(void)

--- a/embed/extmod/modtrezorui/display.c
+++ b/embed/extmod/modtrezorui/display.c
@@ -24,8 +24,8 @@
 #include <string.h>
 #include <stdarg.h>
 
-static int DISPLAY_BACKLIGHT = 0;
-static int DISPLAY_ORIENTATION = 0;
+static int DISPLAY_BACKLIGHT = -1;
+static int DISPLAY_ORIENTATION = -1;
 static int DISPLAY_OFFSET[2] = {0, 0};
 
 #if defined TREZOR_STM32
@@ -67,8 +67,8 @@ static inline void clamp_coords(int x, int y, int w, int h, int *x0, int *y0, in
 
 void display_clear(void)
 {
-    display_set_window(0, 0, DISPLAY_RESX - 1, DISPLAY_RESY - 1);
-    for (int i = 0; i < DISPLAY_RESX * DISPLAY_RESY * 2; i++) {
+    display_set_window_raw(0, 0, MAX_DISPLAY_RESX - 1, MAX_DISPLAY_RESY - 1);
+    for (int i = 0; i < MAX_DISPLAY_RESX * MAX_DISPLAY_RESY * 2; i++) {
         DATA(0x00);
     }
 }

--- a/embed/extmod/modtrezorui/display.h
+++ b/embed/extmod/modtrezorui/display.h
@@ -42,6 +42,7 @@
 
 // provided by port
 
+void display_pwm_init(void);
 int display_init(void);
 void display_refresh(void);
 void display_save(const char *filename);

--- a/embed/extmod/modtrezorui/modtrezorui-display.h
+++ b/embed/extmod/modtrezorui/modtrezorui-display.h
@@ -23,7 +23,6 @@ typedef struct _mp_obj_Display_t {
 ///     '''
 STATIC mp_obj_t mod_trezorui_Display_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     mp_arg_check_num(n_args, n_kw, 0, 0, false);
-    display_init();
     mp_obj_Display_t *o = m_new_obj(mp_obj_Display_t);
     o->base.type = type;
     return MP_OBJ_FROM_PTR(o);

--- a/embed/firmware/main.c
+++ b/embed/firmware/main.c
@@ -27,9 +27,9 @@ int main(void) {
 
     pendsv_init();
 
-    if (0 != display_init()) {
-        __fatal_error("display_init", __FILE__, __LINE__, __FUNCTION__);
-    }
+    display_pwm_init();
+    display_orientation(0);
+    display_backlight(255);
 
     if (0 != flash_init()) {
         __fatal_error("flash_init", __FILE__, __LINE__, __FUNCTION__);


### PR DESCRIPTION
1) Smoothed out the display (re)initializing and clearing to reduce flashing during startup and clear the whole display for 240x320 displays.
Also, removing the `display_init` from the python binding fixes some sporadic artifacts on the trezor.io/start message (the initial screen after the 1 second green SL logo).

With these changes, there is only one white flash at the very beginning, before the display is initialized. That may be solvable by hardware design on the backight pin (just a guess, I did not try this).

Tested with:
```
make build_boardloader DISPLAY_VSYNC=0 DISPLAY_ILI9341V=1
make build_bootloader DISPLAY_VSYNC=0 DISPLAY_ILI9341V=1
make vendorheader
make build_firmware DISPLAY_VSYNC=0 DISPLAY_ILI9341V=1
```

2) Some function brace cleanup while I was touching the files.