### PR TITLE
transition to openocd from st-flash

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ cd trezor-core
 #### Debian/Ubuntu
 
 ```sh
-sudo pip install ed25519 pyblake2
+sudo -H pip install ed25519 pyblake2
 
 sudo dpkg --add-architecture i386
 sudo apt-get update
@@ -73,7 +73,7 @@ Not supported yet ...
 ### Linux
 
 For flashing firmware to blank device (without bootloader) by `make flash`,
-please install [stlink](https://github.com/texane/stlink).
+or `make flash STLINKv21=1` if using a ST-LINK/V2.1 interface.
 
 #### Debian/Ubuntu
 


### PR DESCRIPTION
openocd is solid and this removes dependency on another tool, st-flash.

Tested:

```
make openocd STLINKv21=1
make flash STLINKv21=1
make flash_erase STLINKv21=1
make flash_boardloader STLINKv21=1
make flash_bootloader STLINKv21=1
make flash_firmware STLINKv21=1
make combine flash_combine STLINKv21=1
```