### PR TITLE
clock related updates

### DIFF
--- a/embed/boardloader/startup.s
+++ b/embed/boardloader/startup.s
@@ -393,6 +393,8 @@ memset_reg:
   .global reset_handler
   .type reset_handler, STT_FUNC
 reset_handler:
+  bl SystemInit
+
   // wipe memory to remove any possible vestiges of sensitive data
   ldr r0, =ccmram_start // r0 - point to beginning of CCMRAM
   ldr r1, =ccmram_end   // r1 - point to byte after the end of CCMRAM
@@ -409,9 +411,6 @@ reset_handler:
   ldr r1, =data_lma     // src addr
   ldr r2, =data_size    // size in bytes
   bl memcpy
-
-  // CMSIS initialization
-  bl SystemInit
 
   // enter the application code
   bl main

--- a/embed/bootloader/startup.S
+++ b/embed/bootloader/startup.S
@@ -113,8 +113,6 @@ LoopFillZerobss:
   cmp  r2, r3
   bcc  FillZerobss
 
-/* Call the clock system initialization function.*/
-  bl  SystemInit
 /* Call static constructors */
     /*bl __libc_init_array*/
 /* Call the application's entry point.*/

--- a/embed/firmware/main.c
+++ b/embed/firmware/main.c
@@ -23,11 +23,16 @@
 
 bool firmware_standalone(void)
 {
+    // linker script defined symbol -- reference 3.5.5 in GNU linker manual
     extern const uint32_t _flash_start;
-    return _flash_start == 0x0800000;
+    return &_flash_start == ((uint32_t *) 0x0800000);
 }
 
 int main(void) {
+
+    if (firmware_standalone()) {
+        SystemInit();
+    }
 
     periph_init();
 

--- a/embed/firmware/startup.S
+++ b/embed/firmware/startup.S
@@ -113,8 +113,6 @@ LoopFillZerobss:
   cmp  r2, r3
   bcc  FillZerobss
 
-/* Call the clock system initialization function.*/
-  bl  SystemInit
 /* Call static constructors */
     /*bl __libc_init_array*/
 /* Call the application's entry point.*/

--- a/embed/trezorhal/common.c
+++ b/embed/trezorhal/common.c
@@ -29,8 +29,6 @@ void __attribute__((noreturn)) nlr_jump_fail(void *val) {
     __fatal_error("uncaught exception", __FILE__, __LINE__, __FUNCTION__);
 }
 
-extern void SystemClock_Config(void);
-
 void periph_init(void) {
 
     // STM32F4xx HAL library initialization:
@@ -40,20 +38,11 @@ void periph_init(void) {
     //  - global MSP (MCU Support Package) initialization
     HAL_Init();
 
-    // Set the system clock to be HSE
-    SystemClock_Config();
-
-    // Enable CSS (Clock Security System)
-    HAL_RCC_EnableCSS();
-
     // Enable GPIO clocks
     __HAL_RCC_GPIOA_CLK_ENABLE();
     __HAL_RCC_GPIOB_CLK_ENABLE();
     __HAL_RCC_GPIOC_CLK_ENABLE();
     __HAL_RCC_GPIOD_CLK_ENABLE();
-
-    // Enable the CCM RAM
-    __HAL_RCC_CCMDATARAMEN_CLK_ENABLE();
 
     // Clear the reset flags
     PWR->CR |= PWR_CR_CSBF;

--- a/embed/trezorhal/stm32_system.c
+++ b/embed/trezorhal/stm32_system.c
@@ -89,8 +89,8 @@
 
 #include STM32_HAL_H
 
-#define MICROPY_HW_CLK_PLLM (8)
-#define MICROPY_HW_CLK_PLLN (336)
+#define MICROPY_HW_CLK_PLLM (4)
+#define MICROPY_HW_CLK_PLLN (168)
 #define MICROPY_HW_CLK_PLLP (RCC_PLLP_DIV2)
 #define MICROPY_HW_CLK_PLLQ (7)
 #define MICROPY_HW_CLK_LAST_FREQ (1)
@@ -170,7 +170,7 @@ const uint32_t MSIRangeTable[12] = {100000, 200000, 400000, 800000, 1000000, 200
                is no need to call the 2 first functions listed above, since SystemCoreClock
                variable is updated automatically.
   */
-  uint32_t SystemCoreClock = 16000000;
+  uint32_t SystemCoreClock = 168000000;
 
 /**
   * @}
@@ -197,36 +197,29 @@ const uint32_t MSIRangeTable[12] = {100000, 200000, 400000, 800000, 1000000, 200
   */
 void SystemInit(void)
 {
-  /* FPU settings ------------------------------------------------------------*/
-  #if (__FPU_PRESENT == 1) && (__FPU_USED == 1)
-    SCB->CPACR |= ((3UL << 10*2)|(3UL << 11*2));  /* set CP10 and CP11 Full Access */
-  #endif
-  /* Reset the RCC clock configuration to the default reset state ------------*/
-
-  /* Set HSION bit */
-  RCC->CR |= CONFIG_RCC_CR_1ST;
-
-  /* Reset CFGR register */
-  RCC->CFGR = 0x00000000;
-
-  /* Reset HSEON, CSSON and PLLON bits */
-  RCC->CR &= ~ CONFIG_RCC_CR_2ND;
-
-  /* Reset PLLCFGR register */
-  RCC->PLLCFGR = CONFIG_RCC_PLLCFGR;
-
-  /* Reset HSEBYP bit */
-  RCC->CR &= (uint32_t)0xFFFBFFFF;
-
-  /* Disable all interrupts */
-  #if defined(MCU_SERIES_F4) || defined(MCU_SERIES_F7)
-  RCC->CIR = 0x00000000;
-  #elif defined(MCU_SERIES_L4)
-  RCC->CIER = 0x00000000;
-  #endif
-
-  /* dpgeorge: enable 8-byte stack alignment for IRQ handlers, in accord with EABI */
-  SCB->CCR |= SCB_CCR_STKALIGN_Msk;
+    // set flash wait states for an increasing HCLK frequency -- reference RM0090 section 3.5.1
+    FLASH->ACR = FLASH_ACR_LATENCY_5WS;
+    // configure main PLL; assumes HSE is 8 MHz; this should evaluate to 0x27402a04 -- reference RM0090 section 7.3.2
+    RCC->PLLCFGR = (RCC_PLLCFGR_RST_VALUE & ~RCC_PLLCFGR_PLLQ & ~RCC_PLLCFGR_PLLSRC & ~RCC_PLLCFGR_PLLP & ~RCC_PLLCFGR_PLLN & ~RCC_PLLCFGR_PLLM)
+                   | (7 << RCC_PLLCFGR_PLLQ_Pos)   // Q = 7
+                   | RCC_PLLCFGR_PLLSRC_HSE        // PLLSRC = HSE
+                   | (0 << RCC_PLLCFGR_PLLP_Pos)   // P = 2 (two bits, 00 means PLLP = 2)
+                   | (168 << RCC_PLLCFGR_PLLN_Pos) // N = 168
+                   | (4 << RCC_PLLCFGR_PLLM_Pos);  // M = 4
+    // enable clock security system, HSE clock, and main PLL
+    RCC->CR |= RCC_CR_CSSON | RCC_CR_HSEON | RCC_CR_PLLON;
+    // wait until PLL and HSE ready
+    while((RCC->CR & (RCC_CR_PLLRDY | RCC_CR_HSERDY)) != (RCC_CR_PLLRDY | RCC_CR_HSERDY));
+    // APB2=2, APB1=4, AHB=1, system clock = main PLL
+    RCC->CFGR = RCC_CFGR_PPRE2_DIV2 | RCC_CFGR_PPRE1_DIV4 | RCC_CFGR_HPRE_DIV1 | RCC_CFGR_SW_PLL;
+    // wait until PLL is system clock
+    while((RCC->CFGR & RCC_CFGR_SWS) != RCC_CFGR_SWS_PLL);
+    // turn off the HSI as it is now unused (it will be turned on again automatically if a clock security failure occurs)
+    RCC->CR &= ~RCC_CR_HSION;
+    // enable full access to the fpu coprocessor
+    #if (__FPU_PRESENT == 1) && (__FPU_USED == 1)
+        SCB->CPACR |= ((3UL << 10*2)|(3UL << 11*2));  /* set CP10 and CP11 Full Access */
+    #endif
 }
 
 


### PR DESCRIPTION
It seemed awkward/unclean to me that the clock configs were forgotten and reconfigured by each stage (the `SystemInit` + `periph_init` combo).

My preference is to setup the clock tree early in the boardloader and then be able to bring peripherals online that depend on the clock settings, like the TRNG, as needed.
For example, I'd like to have the HSE+PLL+CSS and TRNG setup before wiping memory so that it could be wiped with unpredictable data (a follow-up to this PR).

These changes configure the PLLM  to 4 instead of 8 to adhere to the RM0090, section 7.3.2, recommendation that: "The software has to set these bits correctly to ensure that the VCO input frequency ranges from 1 to 2 MHz. It is recommended to select a frequency of 2 MHz to limit PLL jitter."

Some unnecessary stuff, like re-enabling the CCMRAM and the stack alignment thing (reference PM0214 section 4.4.7) (note: the STKALIGN is in every version of Cortex-M4, it was not present/set on some revisions of Cortex-M3 according to the revision history in the "Cortex-M3 Processor Technical Reference Manual"), is removed too (there is much more that can be removed, but I wanted to keep the PR reviewable).

Since the HAL is C code, and has the .data/.bss dependencies, it can't be used early in the boardloader because of the memory wiping either. Its clock updating code also has unnecessary dependencies on the SysTick.

Here's the clock tree that this configures:
![clock-tree](https://user-images.githubusercontent.com/29890609/31047228-9c162786-a5d4-11e7-8640-9372c7738567.png)
