### PR TITLE
display: minor backlight handling

### DIFF
--- a/embed/boardloader/main.c
+++ b/embed/boardloader/main.c
@@ -47,6 +47,7 @@ static void progress_callback(uint16_t val) {
 
 bool copy_sdcard(void)
 {
+    display_backlight(255);
     display_printf("erasing flash ");
 
     // erase flash (except boardloader)

--- a/embed/extmod/modtrezorui/display-stm32.h
+++ b/embed/extmod/modtrezorui/display-stm32.h
@@ -139,7 +139,7 @@ void display_pwm_init(void)
     TIM_OC_InitStructure.OCIdleState = TIM_OCIDLESTATE_SET;
     TIM_OC_InitStructure.OCNIdleState = TIM_OCNIDLESTATE_SET;
     HAL_TIM_PWM_ConfigChannel(&TIM1_Handle, &TIM_OC_InitStructure, TIM_CHANNEL_1);
-    display_set_backlight(0);
+    display_backlight(0);
     HAL_TIM_PWM_Start(&TIM1_Handle, TIM_CHANNEL_1);
     HAL_TIMEx_PWMN_Start(&TIM1_Handle, TIM_CHANNEL_1);
 }


### PR DESCRIPTION
Minor updates for your last commit 6693d61aa072d831d77ffad02a66892873ab1220

1) turn on back light to see `copy_sdcard` output

2) use `display_backlight` instead of `display_set_backlight` to also set `DISPLAY_BACKLIGHT` in embed/extmod/modtrezorui/display.c

I like that you turn the back light off earlier now. Good idea. At one point, I was thinking of only using the display in the boardloader for the SD card update messages. But, then I decided to leave the display init in the normal boot flow so that the display memory got cleared.