### PR TITLE
boardloader: simplify linker script

### DIFF
--- a/embed/boardloader/memory.ld
+++ b/embed/boardloader/memory.ld
@@ -3,14 +3,12 @@
 ENTRY(reset_handler)
 
 MEMORY {
-  FLASH  (rx)  : ORIGIN = 0x08000000, LENGTH = 1024K
+  FLASH  (rx)  : ORIGIN = 0x08000000, LENGTH = 32K
   CCMRAM (wal) : ORIGIN = 0x10000000, LENGTH = 64K
-  SRAM   (wal) : ORIGIN = 0x20000000, LENGTH = 128K /* note: the boardloader uses mostly CCMRAM */
+  SRAM   (wal) : ORIGIN = 0x20000000, LENGTH = 128K
 }
 
 main_stack_base = ORIGIN(CCMRAM) + LENGTH(CCMRAM); /* 8-byte aligned full descending stack */
-
-minimum_stack_size = 4K; /* reserve a chunk for stack space */
 
 /* used by the startup code to populate variables used by the C code */
 data_lma = LOADADDR(.data);
@@ -25,50 +23,32 @@ ccmram_end = ORIGIN(CCMRAM) + LENGTH(CCMRAM);
 sram_start = ORIGIN(SRAM);
 sram_end = ORIGIN(SRAM) + LENGTH(SRAM);
 
-/* alignment references refer to sections in the ARM v7-M Architecture Reference Manual */
-
 SECTIONS {
-  .vector_table : ALIGN(512) { /* B1.5.3 and Table 61 of STM32F405 Reference Manual (RM0090) */
-    KEEP(*(.vector_table))
+  .vector_table : ALIGN(512) {
+    KEEP(*(.vector_table));
   } >FLASH AT>FLASH
 
-  .text : ALIGN(4) { /* A3.3.1 - needs at least 2 */
-    KEEP(*(.text)) /* does not match all .text*, but influences their positioning */
-    . = ALIGN(4); /* force the section to end on an word-aligned boundary */
+  .text : ALIGN(4) {
+    *(.text*);
+    . = ALIGN(4); /* make the section size a multiple of the word size */
   } >FLASH AT>FLASH
 
   .rodata : ALIGN(4) {
-    KEEP(*(.rodata)) /* does not match all .rodata*, but influences their positioning */
-    . = ALIGN(4); /* force the section to end on an word-aligned boundary */
+    *(.rodata*);
+    . = ALIGN(4); /* make the section size a multiple of the word size */
   } >FLASH AT>FLASH
 
   .data : ALIGN(4) {
-    KEEP(*(.data*)) /* combine all the .data* so that the startup code can copy it in all at once */
-    . = ALIGN(4); /* force the section to end on an word-aligned boundary */
+    *(.data*);
+    . = ALIGN(4); /* make the section size a multiple of the word size */
   } >CCMRAM AT>FLASH
 
   .bss : ALIGN(4) {
-    KEEP(*(.bss)) /* does not match all .bss*, but influences their positioning */
-    . = ALIGN(4); /* force the section to end on an word-aligned boundary */
+    *(.bss*);
+    . = ALIGN(4); /* make the section size a multiple of the word size */
   } >CCMRAM
 
-  .stack : ALIGN(8) { /* B1.5.7 */
-    . += minimum_stack_size;
-    . = ALIGN(8); /* force the section to end on an double word-aligned boundary */
+  .stack : ALIGN(8) {
+    . = 4K; /* this acts as a build time assertion that at least this much memory is available for stack use */
   } >CCMRAM
-
-  /* todo: reduce unused stuff being linked and garbage collected  */
-  /*       requires moving code around and updating build scripts. */
-  /DISCARD/ : {
-    */embed/extmod/modtrezorui/display.o (.text.get_glyph)
-    */embed/extmod/modtrezorui/display.o (.text.display_image)
-    */embed/extmod/modtrezorui/display.o (.text.display_avatar)
-    */embed/extmod/modtrezorui/display.o (.text.display_icon)
-    */embed/extmod/modtrezorui/display.o (.text.display_qrcode)
-    */embed/extmod/modtrezorui/display.o (.text.display_loader)
-    */embed/extmod/modtrezorui/display.o (.text.display_text)
-    */embed/extmod/modtrezorui/display.o (.text.display_text_width)
-    */embed/extmod/modtrezorui/display.o (.text.display_text_center)
-    */embed/extmod/modtrezorui/display.o (.text.display_text_right)
-  }
 }


### PR DESCRIPTION
More prep work that makes the bootloader and firmware portion of #12 much easier.
I have the bootloader and firmware updates too. I'll push them up later, after more testing.

1) The changes like this: `KEEP(*(.text))` to `*(.text*)`
   These changes fully embrace the link time garbage colector and remove the reliance on details of orphan section processing.
   The script is much more intuitive now. I'm glad that I got past the mental block that made me want to use the `KEEP`s.

2) Sets the FLASH memory region to 32K to act as a build time assertion on the code size

3) Other trivial general cleanup/simplifying changes
