### PR TITLE
boardloader: memset_reg_wrap

### DIFF
--- a/embed/boardloader/startup.s
+++ b/embed/boardloader/startup.s
@@ -18,17 +18,24 @@ reset_handler:
   bl rng_read
   mov r4, r0            // save TRNG output in r4
 
+  // r0 - value returned from previous call
+  ldr r1, =1            // r1 - whether to compare the previous value
+  bl rng_read
+  mov r5, r0            // save TRNG output in r5
+
   // wipe memory to remove any possible vestiges of sensitive data
   // use unpredictable value as a defense against side-channels
   ldr r0, =ccmram_start // r0 - point to beginning of CCMRAM
   ldr r1, =ccmram_end   // r1 - point to byte after the end of CCMRAM
   mov r2, r4            // r2 - the word-sized value to be written
-  bl memset_reg
+  mov r3, r5            // r3 - random offset within the range to start at
+  bl memset_reg_wrap
 
   ldr r0, =sram_start   // r0 - point to beginning of SRAM
   ldr r1, =sram_end     // r1 - point to byte after the end of SRAM
   mov r2, r4            // r2 - the word-sized value to be written
-  bl memset_reg
+  mov r3, r5            // r3 - random offset within the range to start at
+  bl memset_reg_wrap
 
   // setup environment for subsequent stage of code
   ldr r0, =ccmram_start // r0 - point to beginning of CCMRAM


### PR DESCRIPTION
I had this idea floating around... instead of just writing an unpredictable value, also write the range starting from an unpredictable place. I just imagine this making a power analysis type side channel more difficult. It's probably already sufficiently difficult. But, I figured that I'd throw this out there anyways.

Basically, this picks a random word-aligned address within the range to start at, then writes the memory range in a circular way until it gets back to where it started.

Uses separate random values for the data value to write and the address to begin at.