### PR TITLE
boardloader: issue #34

### DIFF
--- a/embed/boardloader/main.c
+++ b/embed/boardloader/main.c
@@ -130,6 +130,7 @@ void check_and_jump(void)
 
 int main(void)
 {
+    clear_peripheral_local_memory();
     periph_init();
 
     if (0 != display_init()) {

--- a/embed/trezorhal/common.c
+++ b/embed/trezorhal/common.c
@@ -2,6 +2,7 @@
 
 #include "common.h"
 #include "display.h"
+#include "rng.h"
 
 void __attribute__((noreturn)) __fatal_error(const char *msg, const char *file, int line, const char *func) {
     for (volatile uint32_t delay = 0; delay < 10000000; delay++) {}
@@ -57,4 +58,13 @@ void periph_init(void) {
 void hal_delay(uint32_t ms)
 {
     HAL_Delay(ms);
+}
+
+void clear_peripheral_local_memory(void)
+{
+    RCC->AHB1ENR |= RCC_AHB1ENR_OTGHSEN; // enable USB_OTG_HS peripheral clock so that the peripheral memory is accessible
+    const uint32_t unpredictable = rng_get();
+    memset_reg((volatile void *) USB_OTG_HS_DATA_FIFO_RAM, (volatile void *) (USB_OTG_HS_DATA_FIFO_RAM + USB_OTG_HS_DATA_FIFO_SIZE), unpredictable);
+    memset_reg((volatile void *) USB_OTG_HS_DATA_FIFO_RAM, (volatile void *) (USB_OTG_HS_DATA_FIFO_RAM + USB_OTG_HS_DATA_FIFO_SIZE), 0);
+    RCC->AHB1ENR &= ~RCC_AHB1ENR_OTGHSEN; // disable USB OTG_HS peripheral clock as the peripheral is not needed right now
 }

--- a/embed/trezorhal/common.h
+++ b/embed/trezorhal/common.h
@@ -8,6 +8,13 @@
 #define FIRMWARE_START     0x08020000
 #define HEADER_SIZE        0x200
 
+#define USB_OTG_HS_DATA_FIFO_RAM  (USB_OTG_HS_PERIPH_BASE + 0x20000U) // reference RM0090 section 35.12.1 Figure 413
+#define USB_OTG_HS_DATA_FIFO_SIZE (4096U)
+
+extern void memset_reg(volatile void *start, volatile void *stop, uint32_t val);
+
+void clear_peripheral_local_memory(void);
+
 void periph_init(void);
 
 void __attribute__((noreturn)) __fatal_error(const char *msg, const char *file, int line, const char *func);


### PR DESCRIPTION
I looked into the peripherals mentioned in https://github.com/trezor/trezor-core/issues/34. Only the USB OTG HS seemed interesting as far as harboring data.
I found that I needed to enable the clock to the peripheral in order to read and write the data, but that was it. I didn't have to set it up more. So, clock it, write the local memory, and unclock it.
I don't think that leaves any unintended side-effects. It doesn't appear to as far as I tested.

Here's a good test:
 1. in gdb, find nothing with: `find 0x40060000,0x4007ffff,"arise! chikun arise!"`
 1. `./trezorctl ping "arise! chikun arise!"`
 1. in gdb, find a bunch of references with the same find command from step 1
 1. Reset the device and step through and pay attention to when the data becomes visible and when it goes away. You'll notice that overwriting the 4KB block removes all of the references due to how the FIFO memory is mapped.