### PR TITLE
Makefile: vendor target add --recursive and --force

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ help: ## show this help
 ## dependencies commands:
 
 vendor: ## update git submodules
-	git submodule update --init
+	git submodule update --init --recursive --force
 
 res: ## update resources
 	./tools/res_collect


### PR DESCRIPTION
This saves me time and makes sure that I am working with fresh versions of the files. Not doing both has bitten me a couple of times.

Without the recursive, you don't get all the submodules. Without force, you can have stale versions of the files.

This shows what additional modules the recursive part picks up:

```
> git submodule update --init
Submodule 'vendor/micropython' (https://github.com/trezor/micropython.git) registered for path 'vendor/micropython'
Submodule 'vendor/nanopb' (https://github.com/nanopb/nanopb.git) registered for path 'vendor/nanopb'
Submodule 'vendor/norcow' (https://github.com/trezor/norcow.git) registered for path 'vendor/norcow'
Submodule 'vendor/trezor-common' (https://github.com/trezor/trezor-common.git) registered for path 'vendor/trezor-common'
Submodule 'vendor/trezor-crypto' (https://github.com/trezor/trezor-crypto.git) registered for path 'vendor/trezor-crypto'
Submodule 'vendor/trezor-qrenc' (https://github.com/trezor/trezor-qrenc.git) registered for path 'vendor/trezor-qrenc'
Submodule path 'vendor/micropython': checked out '6c5f953c797ff32911901215b8d0b7615d84ece8'
Submodule path 'vendor/nanopb': checked out '2c4c3948a9f9e2eb573706a354b89a55cb85639f'
Submodule path 'vendor/norcow': checked out '8d2843aeb58f8fd0fc5162a11d5be1e2575776ca'
Submodule path 'vendor/trezor-common': checked out '0001cb18c065d7f3aacd6f8d7c5be42cd7477a94'
Submodule path 'vendor/trezor-crypto': checked out 'ea227fd805fb97aa2fa76a89bfd05d44012d153f'
Submodule path 'vendor/trezor-qrenc': checked out '9344f23d869030fbe7261d3361862eaba12b9975'
> git submodule update --init --recursive
Submodule path 'vendor/micropython/lib/axtls': checked out '9b3092eb3b4b230a63c0c389bfbd3c55682c620f'
Submodule path 'vendor/micropython/lib/berkeley-db-1.xx': checked out 'dab957dacddcbf6cbc85d42df62e189e4877bb72'
Submodule path 'vendor/micropython/lib/libffi': checked out 'e9de7e35f2339598b16cbb375f9992643ed81209'
Submodule path 'vendor/micropython/lib/lwip': checked out '5b8b5d459e7dd890724515bbfad86c705234f9ec'
Submodule path 'vendor/micropython/lib/stm32lib': checked out 'd2bcfda543d3b99361e44112aca929225bdcc07f'
```