### PR TITLE
RNG: Delay after an RCC peripheral clock enabling

### DIFF
--- a/embed/boardloader/lowlevel.c
+++ b/embed/boardloader/lowlevel.c
@@ -11,11 +11,12 @@
 
 void clear_otg_hs_memory(void)
 {
-    RCC->AHB1ENR |= RCC_AHB1ENR_OTGHSEN; // enable USB_OTG_HS peripheral clock so that the peripheral memory is accessible
+    // use the HAL version due to section 2.1.6 of STM32F42xx Errata sheet
+    __HAL_RCC_USB_OTG_HS_CLK_ENABLE(); // enable USB_OTG_HS peripheral clock so that the peripheral memory is accessible
     const uint32_t unpredictable = rng_get();
     memset_reg((volatile void *) USB_OTG_HS_DATA_FIFO_RAM, (volatile void *) (USB_OTG_HS_DATA_FIFO_RAM + USB_OTG_HS_DATA_FIFO_SIZE), unpredictable);
     memset_reg((volatile void *) USB_OTG_HS_DATA_FIFO_RAM, (volatile void *) (USB_OTG_HS_DATA_FIFO_RAM + USB_OTG_HS_DATA_FIFO_SIZE), 0);
-    RCC->AHB1ENR &= ~RCC_AHB1ENR_OTGHSEN; // disable USB OTG_HS peripheral clock as the peripheral is not needed right now
+    __HAL_RCC_USB_OTG_HS_CLK_DISABLE(); // disable USB OTG_HS peripheral clock as the peripheral is not needed right now
 }
 
 #define WANTED_WRP (OB_WRP_SECTOR_0 | OB_WRP_SECTOR_1 | OB_WRP_SECTOR_2)

--- a/embed/trezorhal/rng.c
+++ b/embed/trezorhal/rng.c
@@ -2,7 +2,10 @@
 
 int rng_init(void)
 {
-    RCC->AHB2ENR |= RCC_AHB2ENR_RNGEN; // enable TRNG peripheral clock
+    // enable TRNG peripheral clock
+    // use the HAL version due to section 2.1.6 of STM32F42xx Errata sheet
+    // "Delay after an RCC peripheral clock enabling"
+    __HAL_RCC_RNG_CLK_ENABLE();
     RNG->CR = RNG_CR_RNGEN; // enable TRNG
     return 0;
 }


### PR DESCRIPTION
I was going through the STM32F42xx and STM32F43xx Errata sheet and found this: 2.1.6 "Delay after an RCC peripheral clock enabling". The HAL handles it better. Let's use that here.

@prusnak  heads-up to check this one in the errata sheet too:
"2.1.11 Data cache might be corrupted during Flash read-while-write operation"
Not sure if that affects how you were going to use the flash (the memory layout docs that you updated yesterday came to mind when I saw this one).