### PR TITLE
docs: bootloader microsd creation note and typo fix

### DIFF
--- a/docs/bootloader.md
+++ b/docs/bootloader.md
@@ -29,6 +29,17 @@ if it did not, then a corruption/erasure of later stage flash memory would
 leave the device unusable (only the boardloader could run and it would not
 pass execution to a later stage that fails signature validation).
 
+Developer note:
+
+A microSD card can be prepared with the following. Note that the bootloader is allocated 128 KiB.
+
+WARNING: Ensure that you want to overwrite and destroy the contents of `/dev/mmcblk0` before running these commands.
+Likewise, `/dev/mmcblk0` may be replaced by your own specific destination.
+
+ 1. `sudo dd if=/dev/zero of=/dev/mmcblk0 bs=512 count=256 conv=fsync`
+
+ 1. `sudo dd if=build/bootloader/bootloader.bin of=/dev/mmcblk0 bs=512 conv=fsync`
+
 ## Second Stage - Bootloader
 
 Second stage checks the integrity and signatures of the firmware and runs

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -9,7 +9,7 @@
 | Sector  2 | 0x08008000 - 0x0800BFFF |  16 KiB | boardloader (1st stage) (write-protected)
 | Sector  3 | 0x0800C000 - 0x0800FFFF |  16 KiB | ?
 | Sector  4 | 0x08010000 - 0x0801FFFF |  64 KiB | storage area #1
-| Sector  5 | 0x08020000 - 0x0803FFFF | 128 KiB | boardloader (2nd stage)
+| Sector  5 | 0x08020000 - 0x0803FFFF | 128 KiB | bootloader (2nd stage)
 | Sector  6 | 0x08040000 - 0x0805FFFF | 128 KiB | firmware
 | Sector  7 | 0x08060000 - 0x0807FFFF | 128 KiB | firmware
 | Sector  8 | 0x08080000 - 0x0809FFFF | 128 KiB | firmware


### PR DESCRIPTION
add notes on how to manually create a bootloader microSD and fix a typo.

i was going to make this a make target, but then figured that i didn't want to make it a dangerous footgun tool.