### PR TITLE
code cleanup

### DIFF
--- a/SConscript.boardloader
+++ b/SConscript.boardloader
@@ -104,7 +104,7 @@ env.Replace(
     '-fstack-protector-all -ffreestanding '
     + CCFLAGS_MOD,
     CCFLAGS_QSTR='-DNO_QSTR -DN_X64 -DN_X86 -DN_THUMB',
-    LINKFLAGS='-nostdlib -T embed/boardloader/memory.ld --gc-sections',
+    LINKFLAGS='-nostdlib -T embed/boardloader/memory.ld --gc-sections -Map=build/boardloader/boardloader.map',
     CPPPATH=[
         'embed/boardloader',
         'embed/trezorhal',

--- a/embed/trezorhal/common.c
+++ b/embed/trezorhal/common.c
@@ -30,7 +30,7 @@ void __attribute__((noreturn)) __fatal_error(const char *expr, const char *msg, 
     for (;;);
 }
 
-uint32_t __stack_chk_guard;
+uint32_t __stack_chk_guard = 0;
 
 void __attribute__((noreturn)) __stack_chk_fail(void)
 {

--- a/embed/trezorhal/rng.c
+++ b/embed/trezorhal/rng.c
@@ -1,13 +1,14 @@
 #include STM32_HAL_H
 
-int rng_init(void)
+#pragma GCC optimize("no-stack-protector") // applies to all functions in this file
+
+void rng_init(void)
 {
     // enable TRNG peripheral clock
     // use the HAL version due to section 2.1.6 of STM32F42xx Errata sheet
     // "Delay after an RCC peripheral clock enabling"
     __HAL_RCC_RNG_CLK_ENABLE();
     RNG->CR = RNG_CR_RNGEN; // enable TRNG
-    return 0;
 }
 
 uint32_t rng_read(const uint32_t previous, const uint32_t compare_previous)

--- a/embed/trezorhal/rng.h
+++ b/embed/trezorhal/rng.h
@@ -1,7 +1,7 @@
 #ifndef __TREZORHAL_RNG_H__
 #define __TREZORHAL_RNG_H__
 
-int rng_init(void);
+void rng_init(void);
 uint32_t rng_get(void);
 uint32_t rng_read(const uint32_t previous, const uint32_t compare_previous);
 

--- a/embed/trezorhal/stm32.c
+++ b/embed/trezorhal/stm32.c
@@ -45,5 +45,7 @@ volatile uint32_t uwTick = 0;
 
 void SysTick_Handler(void)
 {
-    uwTick += 1;
+    // this is a millisecond tick counter that wraps after approximately
+    // 49.71 days = (0xffffffff / (24 * 60 * 60 * 1000))
+    uwTick++;
 }

--- a/embed/trezorhal/stm32.c
+++ b/embed/trezorhal/stm32.c
@@ -41,13 +41,9 @@ void SystemInit(void)
     SCB->CPACR |= ((3U << 22) | (3U << 20));
 }
 
+volatile uint32_t uwTick = 0;
+
 void SysTick_Handler(void)
 {
-    extern volatile uint32_t uwTick;
     uwTick += 1;
-    // TODO: verify the following claim, or remove
-    // Read the systick control regster. This has the side effect of clearing
-    // the COUNTFLAG bit, which makes the logic in sys_tick_get_microseconds
-    // work properly.
-    SysTick->CTRL;
 }


### PR DESCRIPTION
It was easier to do this all together.

 * disable stack protector for the 3 rng functions: rng_init, rng_read, and rng_get
 * change return type of rng_init to void
 * in multiple spots, i added type qualifiers to unsigned literals (just being pedantic)
 * in stm32.c, the previous way of disabling the stack protector was still applying to all the functions in the file, no matter what i tried. so i switched to the explicit pragma for the whole file (reference gcc manual section 6.61.15).
 * changed the type of `cfgr` from int to uint32_t (just being pedantic)
 * removed the fpu coprocessor preprocessor stuff since it's always been enabled and always will be
 * `SysTick_Handler` removed some bad comments. the machine code generated is actually the same. we want volatile specified so that reads of the shared variable don't miss writes too. we do not want the compiler optimizing updates to uwTick so that only the handler sees them.