### PR TITLE
boardloader, bootloader, firmware: factor out display_pwm_init

### DIFF
--- a/embed/bootloader/main.c
+++ b/embed/bootloader/main.c
@@ -197,9 +197,7 @@ int main(void)
 
     periph_init();
 
-    display_pwm_init();
     display_orientation(0);
-    display_backlight(0);
 
     ensure(0 == touch_init(), NULL);
 

--- a/embed/extmod/modtrezorui/display.h
+++ b/embed/extmod/modtrezorui/display.h
@@ -44,7 +44,6 @@
 
 // provided by port
 
-void display_pwm_init(void);
 int display_init(void);
 void display_refresh(void);
 void display_save(const char *filename);

--- a/embed/firmware/main.c
+++ b/embed/firmware/main.c
@@ -28,9 +28,7 @@ int main(void)
 
     pendsv_init();
 
-    display_pwm_init();
     display_orientation(0);
-    display_backlight(255);
 
     ensure(0 == flash_init(), NULL);
     ensure(0 == sdcard_init(), NULL);


### PR DESCRIPTION
addressing https://github.com/trezor/trezor-core/issues/50.

the diff looks a little weird. just keep in mind that i removed `display_pwm_init` and it will make more sense.

also removed some extra calls to `display_backlight`.

will probably do something similar with `periph_init` later.