### PR TITLE
SDIO: remove SDIO_IRQHandler and interrupt config

### DIFF
--- a/embed/trezorhal/sdcard.c
+++ b/embed/trezorhal/sdcard.c
@@ -30,9 +30,6 @@
 
 #include "sdcard.h"
 
-#define IRQ_PRI_SDIO            4
-#define IRQ_SUBPRI_SDIO         0
-
 static SD_HandleTypeDef sd_handle;
 
 int sdcard_init(void) {
@@ -64,16 +61,10 @@ int sdcard_init(void) {
 void HAL_SD_MspInit(SD_HandleTypeDef *hsd) {
     // enable SDIO clock
     __HAL_RCC_SDIO_CLK_ENABLE();
-
-    // NVIC configuration for SDIO interrupts
-    HAL_NVIC_SetPriority(SDIO_IRQn, IRQ_PRI_SDIO, IRQ_SUBPRI_SDIO);
-    HAL_NVIC_EnableIRQ(SDIO_IRQn);
-
     // GPIO have already been initialised by sdcard_init
 }
 
 void HAL_SD_MspDeInit(SD_HandleTypeDef *hsd) {
-    HAL_NVIC_DisableIRQ(SDIO_IRQn);
     __HAL_RCC_SDIO_CLK_DISABLE();
 }
 
@@ -135,10 +126,6 @@ uint64_t sdcard_get_capacity_in_bytes(void) {
     HAL_SD_CardInfoTypeDef cardinfo;
     HAL_SD_GetCardInfo(&sd_handle, &cardinfo);
     return (uint64_t)cardinfo.LogBlockNbr * (uint64_t)cardinfo.LogBlockSize;
-}
-
-void SDIO_IRQHandler(void) {
-    HAL_SD_IRQHandler(&sd_handle);
 }
 
 static HAL_StatusTypeDef sdcard_wait_finished(SD_HandleTypeDef *sd, uint32_t timeout) {


### PR DESCRIPTION
Addressing https://github.com/trezor/trezor-core/issues/49

With these changes, the boardloader vector table is clean.
I've tested that the boardloader SDIO stuff works with this code removed. I was able to put a new bootloader on and install a firmware using that (Nice work! Those are changes from today that I haven't reviewed other than to run functional tests so far).

The bootloader already did not have this interrupt handler in its vector table.

That left the firmware as the only place that might use SDIO interrupts. Upon further inspection, I don't think we use SDIO interrupts anywhere, so I've removed the IRQ setup etc...