### PR TITLE
boardloader, bootloader, firmware: only call periph_init in boardloader

### DIFF
--- a/embed/boardloader/main.c
+++ b/embed/boardloader/main.c
@@ -1,3 +1,5 @@
+#include STM32_HAL_H
+
 #include <string.h>
 
 #include "common.h"
@@ -146,6 +148,31 @@ static const uint8_t * const BOARDLOADER_KEYS[] = {
     (const uint8_t *)"\x22\xfc\x29\x77\x92\xf0\xb6\xff\xc0\xbf\xcf\xdb\x7e\xdb\x0c\x0a\xa1\x4e\x02\x5a\x36\x5e\xc0\xe3\x42\xe8\x6e\x38\x29\xcb\x74\xb6",
 #endif
 };
+
+void periph_init(void)
+{
+    // STM32F4xx HAL library initialization:
+    //  - configure the Flash prefetch, instruction and data caches
+    //  - configure the Systick to generate an interrupt each 1 msec
+    //  - set NVIC Group Priority to 4
+    //  - global MSP (MCU Support Package) initialization
+    HAL_Init();
+
+    // Enable GPIO clocks
+    __HAL_RCC_GPIOA_CLK_ENABLE();
+    __HAL_RCC_GPIOB_CLK_ENABLE();
+    __HAL_RCC_GPIOC_CLK_ENABLE();
+    __HAL_RCC_GPIOD_CLK_ENABLE();
+
+    // Clear the reset flags
+    PWR->CR |= PWR_CR_CSBF;
+    RCC->CSR |= RCC_CSR_RMVF;
+
+    // Enable CPU ticks
+    CoreDebug->DEMCR |= CoreDebug_DEMCR_TRCENA_Msk;  // Enable DWT
+    DWT->CYCCNT = 0;  // Reset Cycle Count Register
+    DWT->CTRL |= DWT_CTRL_CYCCNTENA_Msk;  // Enable Cycle Count Register
+}
 
 int main(void)
 {

--- a/embed/bootloader/main.c
+++ b/embed/bootloader/main.c
@@ -212,8 +212,6 @@ int main(void)
     check_bootloader_version();
 #endif
 
-    periph_init();
-
     display_orientation(0);
 
     ensure(0 == touch_init(), NULL);

--- a/embed/firmware/main.c
+++ b/embed/firmware/main.c
@@ -24,8 +24,6 @@
 int main(void)
 {
 
-    periph_init();
-
     pendsv_init();
 
     display_orientation(0);

--- a/embed/trezorhal/common.c
+++ b/embed/trezorhal/common.c
@@ -43,31 +43,6 @@ void __assert_func(const char *file, int line, const char *func, const char *exp
 }
 #endif
 
-void periph_init(void) {
-
-    // STM32F4xx HAL library initialization:
-    //  - configure the Flash prefetch, instruction and data caches
-    //  - configure the Systick to generate an interrupt each 1 msec
-    //  - set NVIC Group Priority to 4
-    //  - global MSP (MCU Support Package) initialization
-    HAL_Init();
-
-    // Enable GPIO clocks
-    __HAL_RCC_GPIOA_CLK_ENABLE();
-    __HAL_RCC_GPIOB_CLK_ENABLE();
-    __HAL_RCC_GPIOC_CLK_ENABLE();
-    __HAL_RCC_GPIOD_CLK_ENABLE();
-
-    // Clear the reset flags
-    PWR->CR |= PWR_CR_CSBF;
-    RCC->CSR |= RCC_CSR_RMVF;
-
-    // Enable CPU ticks
-    CoreDebug->DEMCR |= CoreDebug_DEMCR_TRCENA_Msk;  // Enable DWT
-    DWT->CYCCNT = 0;  // Reset Cycle Count Register
-    DWT->CTRL |= DWT_CTRL_CYCCNTENA_Msk;  // Enable Cycle Count Register
-}
-
 void hal_delay(uint32_t ms)
 {
     HAL_Delay(ms);

--- a/embed/trezorhal/common.h
+++ b/embed/trezorhal/common.h
@@ -12,8 +12,6 @@ extern void memset_reg(volatile void *start, volatile void *stop, uint32_t val);
 
 void clear_otg_hs_memory(void);
 
-void periph_init(void);
-
 void __attribute__((noreturn)) __fatal_error(const char *expr, const char *msg, const char *file, int line, const char *func);
 
 #define ensure(expr, msg) ((expr) ? (void)0 : __fatal_error(#expr, msg, __FILE__, __LINE__, __func__))


### PR DESCRIPTION
don't need to call `periph_init` from each stage. just call it once in the boardloader.

future PR todos:
 * i still have to research the flash caching to see if that's desirable for this particular application. (errata notes)

 * some of the other things going on in periph_init also seem unnecessary.

 * might further consolidate where the clocks are enabled (right now it's split between here and `display_init` for example).
