### PR TITLE
boardloader: disable flash data cache

### DIFF
--- a/embed/trezorhal/stm32f4xx_hal_conf.h
+++ b/embed/trezorhal/stm32f4xx_hal_conf.h
@@ -157,7 +157,7 @@
 #define  USE_RTOS                     0
 #define  PREFETCH_ENABLE              1
 #define  INSTRUCTION_CACHE_ENABLE     1
-#define  DATA_CACHE_ENABLE            1
+#define  DATA_CACHE_ENABLE            0
 
 /* ########################## Assert Selection ############################## */
 /**


### PR DESCRIPTION
This is related to the switch to STM32F42X.

This change disables the HAL from enabling the flash data cache and leaves the instruction and prefetch caches enabled. The instruction cache is required for the SDIO code to work (strange but true).

Motivation is section 2.1.11, "Data cache might be corrupted during Flash read-while-write operation" of the STM32F42xx and STM32F43xx Errata sheet:

```
When a write operation to the internal Flash memory is done, the data cache is updated to
reflect the data update. If a read operation to the other memory bank occurs during the data
cache update, the data cache content may be corrupted. In this case, subsequent read
operations from the same address (Cache hits) will be corrupted.
This issue only occurs in dual bank mode when reading (data access or code execution)
from one Flash bank while writing to the other Flash bank with data cache enabled.
```

My 429 board works both before and after this change. But, I just want to avoid this errata possibly being an issue with the boardloader's microSD + flash erasing code.