### PR TITLE
boardloader: stop enabling debug features to get clock cycle counts

### DIFF
--- a/embed/boardloader/lowlevel.c
+++ b/embed/boardloader/lowlevel.c
@@ -62,9 +62,4 @@ void periph_init(void)
     // Clear the reset flags
     PWR->CR |= PWR_CR_CSBF;
     RCC->CSR |= RCC_CSR_RMVF;
-
-    // Enable CPU ticks
-    CoreDebug->DEMCR |= CoreDebug_DEMCR_TRCENA_Msk;  // Enable DWT
-    DWT->CYCCNT = 0;  // Reset Cycle Count Register
-    DWT->CTRL |= DWT_CTRL_CYCCNTENA_Msk;  // Enable Cycle Count Register
 }


### PR DESCRIPTION
This removes some micropython related code that enables debug features with the intention of retrieving clock cycle counts.

It seems like a bad idea to enable this stuff (in the boardloader):

"TRCENA...Global enable for all DWT and ITM features"

"The DWT contains support for both invasive and non-invasive debug features."

No, thanks.