### PR TITLE
vendor_parse_header: remove undefined behavior add todos

### DIFF
--- a/embed/bootloader/main.c
+++ b/embed/bootloader/main.c
@@ -266,14 +266,14 @@ int main(void)
         hal_delay(1);
     }
 
+    vendor_header vhdr;
+
     // start the bootloader if user touched the screen or no firmware installed
-    if (touched || !vendor_parse_header((const uint8_t *)FIRMWARE_START, NULL)) {
+    if (touched || !vendor_parse_header((const uint8_t *)FIRMWARE_START, &vhdr)) {
         if (!bootloader_loop()) {
             shutdown();
         }
     }
-
-    vendor_header vhdr;
 
     ensure(
         vendor_parse_header((const uint8_t *)FIRMWARE_START, &vhdr),

--- a/embed/bootloader/messages.c
+++ b/embed/bootloader/messages.c
@@ -212,7 +212,8 @@ void process_msg_Initialize(uint8_t iface_num, uint32_t msg_size, uint8_t *buf)
     MSG_SEND_ASSIGN_VALUE(minor_version, VERSION_MINOR);
     MSG_SEND_ASSIGN_VALUE(patch_version, VERSION_PATCH);
     MSG_SEND_ASSIGN_VALUE(bootloader_mode, true);
-    bool firmware_present = vendor_parse_header((const uint8_t *)FIRMWARE_START, NULL);
+    vendor_header vhdr;
+    bool firmware_present = vendor_parse_header((const uint8_t *)FIRMWARE_START, &vhdr);
     MSG_SEND_ASSIGN_VALUE(firmware_present, firmware_present);
     MSG_SEND(Features);
 }

--- a/embed/trezorhal/image.c
+++ b/embed/trezorhal/image.c
@@ -81,18 +81,14 @@ bool image_check_signature(const uint8_t *data, const image_header *hdr, uint8_t
 
 bool vendor_parse_header(const uint8_t *data, vendor_header *vhdr)
 {
-    if (!vhdr) {
-        vendor_header h;
-        vhdr = &h;
-    }
-
     memcpy(&vhdr->magic, data, 4);
     if (vhdr->magic != 0x565A5254) return false; // TRZV
 
     memcpy(&vhdr->hdrlen, data + 4, 4);
+    // todo: sanity check hdr->hdrlen as it is used as a src to memcpy below
 
     memcpy(&vhdr->expiry, data + 8, 4);
-    if (vhdr->expiry != 0) return false;
+    if (vhdr->expiry != 0) return false; // todo: then what is the point of having this field?
 
     memcpy(&vhdr->version, data + 12, 2);
 


### PR DESCRIPTION
title says it all.
the undefined behavior is when using a pointer to a variable that has gone out of scope.