### PR TITLE
build: further cleanup common symbols

### DIFF
--- a/SConscript.boardloader
+++ b/SConscript.boardloader
@@ -98,13 +98,13 @@ env.Replace(
     CCFLAGS='-Os '
     '-g3 '
     '-nostdlib '
-    '-std=gnu99 -Wall -Werror -Wdouble-promotion -Wpointer-arith '
+    '-std=gnu99 -Wall -Werror -Wdouble-promotion -Wpointer-arith -fno-common '
     '-mthumb -mtune=cortex-m4 -mcpu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=hard '
     '-fsingle-precision-constant -fdata-sections -ffunction-sections '
     '-fstack-protector-all -ffreestanding '
     + CCFLAGS_MOD,
     CCFLAGS_QSTR='-DNO_QSTR -DN_X64 -DN_X86 -DN_THUMB',
-    LINKFLAGS='-nostdlib -T embed/boardloader/memory.ld --gc-sections -Map=build/boardloader/boardloader.map',
+    LINKFLAGS='-nostdlib -T embed/boardloader/memory.ld --gc-sections -Map=build/boardloader/boardloader.map --warn-common',
     CPPPATH=[
         'embed/boardloader',
         'embed/trezorhal',

--- a/SConscript.bootloader
+++ b/SConscript.bootloader
@@ -115,13 +115,13 @@ env.Replace(
     CCFLAGS='-Os '
     '-g3 '
     '-nostdlib '
-    '-std=gnu99 -Wall -Werror -Wdouble-promotion -Wpointer-arith '
+    '-std=gnu99 -Wall -Werror -Wdouble-promotion -Wpointer-arith -fno-common '
     '-mthumb -mtune=cortex-m4 -mcpu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=hard '
     '-fsingle-precision-constant -fdata-sections -ffunction-sections '
     '-fstack-protector-all -ffreestanding '
     + CCFLAGS_MOD,
     CCFLAGS_QSTR='-DNO_QSTR -DN_X64 -DN_X86 -DN_THUMB',
-    LINKFLAGS='-nostdlib -T embed/bootloader/memory.ld --gc-sections',
+    LINKFLAGS='-nostdlib -T embed/bootloader/memory.ld --gc-sections -Map=build/bootloader/bootloader.map --warn-common',
     CPPPATH=[
         'embed/bootloader',
         'embed/bootloader/nanopb',

--- a/SConscript.firmware
+++ b/SConscript.firmware
@@ -320,13 +320,13 @@ env.Replace(
     CCFLAGS='$COPT '
     '-g3 '
     '-nostdlib '
-    '-std=gnu99 -Wall -Werror -Wdouble-promotion -Wpointer-arith '
+    '-std=gnu99 -Wall -Werror -Wdouble-promotion -Wpointer-arith -fno-common '
     '-mthumb -mtune=cortex-m4 -mcpu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=hard '
     '-fsingle-precision-constant -fdata-sections -ffunction-sections '
     + CCFLAGS_MOD,
     CCFLAGS_QSTR='-DNO_QSTR -DN_X64 -DN_X86 -DN_THUMB',
     CCFLAGS_OPT='-O3',
-    LINKFLAGS='-nostdlib -T embed/firmware/memory.ld --gc-sections',
+    LINKFLAGS='-nostdlib -T embed/firmware/memory.ld --gc-sections -Map=build/firmware/firmware.map --warn-common',
     CPPPATH=[
         '.',
         'embed/firmware',

--- a/embed/trezorhal/stm32.c
+++ b/embed/trezorhal/stm32.c
@@ -41,7 +41,7 @@ void SystemInit(void)
     SCB->CPACR |= ((3U << 22) | (3U << 20));
 }
 
-volatile uint32_t uwTick = 0;
+extern volatile uint32_t uwTick;
 
 void SysTick_Handler(void)
 {


### PR DESCRIPTION
The common symbol stuff was still a little sloppy (my own doing) so I cleaned it up for the boardloader, bootloader, and firmware. The variables were effectively all getting placed at the end of .bss. This does not change that. This just makes it a little more explicit that that is the intention, and it also makes multiple definitions output a warning (a sign of sloppiness).

```
COMMON         0x000000001000055c       0x20 build/boardloader/vendor/micropython/lib/stm32lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_flash.o
               0x000000001000055c                pFlash

becomes

 .bss.pFlash   0x00000000100004cc       0x20 build/boardloader/vendor/micropython/lib/stm32lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_flash.o
```

```
COMMON         0x00000000100010e4       0x20 build/bootloader/vendor/micropython/lib/stm32lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_flash.o
               0x00000000100010e4                pFlash

becomes

 .bss.pFlash   0x0000000010000714       0x20 build/bootloader/vendor/micropython/lib/stm32lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_flash.o
```

```
 COMMON         0x00000000200030f0        0x4 build/firmware/vendor/micropython/lib/utils/interrupt_char.o
                0x00000000200030f0                mp_interrupt_char
 COMMON         0x00000000200030f4      0x1e4 build/firmware/vendor/micropython/py/mpstate.o
                0x00000000200030f4                mp_state_ctx
 COMMON         0x00000000200032d8        0x4 build/firmware/vendor/micropython/ports/stm32/pendsv.o
                0x00000000200032d8                pendsv_object
 COMMON         0x00000000200032dc       0x20 build/firmware/vendor/micropython/lib/stm32lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_flash.o
                0x00000000200032dc                pFlash
becomes

 .bss.mp_interrupt_char 0x0000000020002694        0x4 build/firmware/vendor/micropython/lib/utils/interrupt_char.o
 .bss.mp_state_ctx      0x00000000200026a0      0x1e4 build/firmware/vendor/micropython/py/mpstate.o
 .bss.pendsv_object     0x0000000020002884        0x4 build/firmware/vendor/micropython/ports/stm32/pendsv.o
 .bss.pFlash            0x0000000020002888       0x20 build/firmware/vendor/micropython/lib/stm32lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_flash.o
```

```
And uwTick stays in .bss:

 .bss.uwTick    0x00000000100004ec        0x4 build/boardloader/vendor/micropython/lib/stm32lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal.o
 .bss.uwTick    0x0000000010000734        0x4 build/bootloader/vendor/micropython/lib/stm32lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal.o
 .bss.uwTick    0x00000000200028a8        0x4 build/firmware/vendor/micropython/lib/stm32lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal.o
```
