### PR TITLE
boardloader, flash: flash option bytes updates, remove flash_init

### DIFF
--- a/embed/boardloader/main.c
+++ b/embed/boardloader/main.c
@@ -165,7 +165,6 @@ int main(void)
     periph_init();
 
     ensure(0 == display_init(), NULL);
-    ensure(0 == flash_init(), NULL);
     ensure(0 == sdcard_init(), NULL);
 
     if (check_sdcard()) {

--- a/embed/boardloader/main.c
+++ b/embed/boardloader/main.c
@@ -149,6 +149,8 @@ static const uint8_t * const BOARDLOADER_KEYS[] = {
 
 int main(void)
 {
+    periph_init(); // need the systick timer running before the production flash (and many other HAL) operations
+
 #if PRODUCTION
     flash_set_option_bytes();
     if (!flash_check_option_bytes()) {
@@ -162,7 +164,6 @@ int main(void)
 #endif
 
     clear_otg_hs_memory();
-    periph_init();
 
     ensure(0 == display_init(), NULL);
     ensure(0 == sdcard_init(), NULL);

--- a/embed/bootloader/main.c
+++ b/embed/bootloader/main.c
@@ -155,7 +155,6 @@ int usb_init_all(void) {
 
 bool bootloader_loop(void)
 {
-    ensure(0 == flash_init(), NULL);
     ensure(0 == usb_init_all(), NULL);
 
     display_clear();

--- a/embed/firmware/main.c
+++ b/embed/firmware/main.c
@@ -27,7 +27,6 @@ int main(void)
 
     display_orientation(0);
 
-    ensure(0 == flash_init(), NULL);
     ensure(0 == sdcard_init(), NULL);
     ensure(0 == touch_init(), NULL);
 

--- a/embed/trezorhal/flash.c
+++ b/embed/trezorhal/flash.c
@@ -35,11 +35,6 @@ static const uint32_t SECTOR_TABLE[SECTOR_COUNT + 1] = {
     [24] = 0x08200000, // last element - not a valid sector
 };
 
-int flash_init(void)
-{
-    return 0;
-}
-
 bool flash_unlock(void)
 {
     HAL_FLASH_Unlock();


### PR DESCRIPTION
First, I trivially removed the empty `flash_init` function from the boardloader, bootloader, and firmware.

Second, I updated the flash option byte code. Notice that I changed the `opts.OptionType =` to `opts.OptionType |=`. After looking through the HAL code, I believe the new way is the correct usage.
I also made the option byte setting code erase other non-boardloader flash sectors, attempt to write the option bytes, and then loop again to check, repeating until they are set. Untested code, but probably close.