### PR TITLE
boardloader: enable PVD programmable voltage detector and interrupt, don't clear standby flag

### DIFF
--- a/embed/boardloader/lowlevel.c
+++ b/embed/boardloader/lowlevel.c
@@ -76,7 +76,20 @@ void periph_init(void)
     HAL_PWR_ConfigPVD(&pvd_config);
     HAL_PWR_EnablePVD();
     NVIC_EnableIRQ(PVD_IRQn);
+}
 
-    // Clear the reset flags
-    RCC->CSR |= RCC_CSR_RMVF;
+bool reset_flags_init(void)
+{
+#if PRODUCTION
+    // this is effective enough that it makes development painful, so only use it for production.
+    // check the reset flags to assure that we arrive here due to a regular full power-on event,
+    // and not as a result of a lesser reset.
+    if ((RCC->CSR & (RCC_CSR_LPWRRSTF | RCC_CSR_WWDGRSTF | RCC_CSR_IWDGRSTF | RCC_CSR_SFTRSTF | RCC_CSR_PORRSTF | RCC_CSR_PINRSTF | RCC_CSR_BORRSTF)) != (RCC_CSR_PORRSTF | RCC_CSR_PINRSTF | RCC_CSR_BORRSTF)) {
+        return false;
+    }
+#endif
+
+    RCC->CSR |= RCC_CSR_RMVF; // clear the reset flags
+
+    return true;
 }

--- a/embed/boardloader/lowlevel.c
+++ b/embed/boardloader/lowlevel.c
@@ -64,6 +64,19 @@ void periph_init(void)
     __HAL_RCC_GPIOC_CLK_ENABLE();
     __HAL_RCC_GPIOD_CLK_ENABLE();
 
+    // enable the PVD (programmable voltage detector).
+    // select the "2.7V" threshold (level 5). the typical electrical
+    // characteristic values are similar to BOR level 3.
+    // this detector will be active regardless of the
+    // flash option byte BOR setting.
+    __HAL_RCC_PWR_CLK_ENABLE();
+    PWR_PVDTypeDef pvd_config;
+    pvd_config.PVDLevel = PWR_PVDLEVEL_5;
+    pvd_config.Mode = PWR_PVD_MODE_IT_RISING_FALLING;
+    HAL_PWR_ConfigPVD(&pvd_config);
+    HAL_PWR_EnablePVD();
+    NVIC_EnableIRQ(PVD_IRQn);
+
     // Clear the reset flags
     PWR->CR |= PWR_CR_CSBF;
     RCC->CSR |= RCC_CSR_RMVF;

--- a/embed/boardloader/lowlevel.c
+++ b/embed/boardloader/lowlevel.c
@@ -78,6 +78,5 @@ void periph_init(void)
     NVIC_EnableIRQ(PVD_IRQn);
 
     // Clear the reset flags
-    PWR->CR |= PWR_CR_CSBF;
     RCC->CSR |= RCC_CSR_RMVF;
 }

--- a/embed/boardloader/lowlevel.h
+++ b/embed/boardloader/lowlevel.h
@@ -6,5 +6,6 @@
 void flash_set_option_bytes(void);
 bool flash_check_option_bytes(void);
 void periph_init(void);
+bool reset_flags_init(void);
 
 #endif

--- a/embed/boardloader/main.c
+++ b/embed/boardloader/main.c
@@ -151,6 +151,10 @@ int main(void)
 {
     periph_init(); // need the systick timer running before the production flash (and many other HAL) operations
 
+    if (!reset_flags_init()) {
+        return 1;
+    }
+
 #if PRODUCTION
     flash_set_option_bytes();
     if (!flash_check_option_bytes()) {

--- a/embed/boardloader/main.c
+++ b/embed/boardloader/main.c
@@ -173,8 +173,7 @@ int main(void)
     sdcard_init();
 
     if (check_sdcard()) {
-        copy_sdcard();
-        shutdown();
+        return copy_sdcard() ? 0 : 3;
     }
 
     image_header hdr;

--- a/embed/boardloader/main.c
+++ b/embed/boardloader/main.c
@@ -163,7 +163,7 @@ int main(void)
             FLASH_SECTOR_STORAGE_2,
         };
         flash_erase_sectors(sectors, 2, NULL);
-        ensure(0, "wrong option bytes");
+        return 2;
     }
 #endif
 

--- a/embed/boardloader/startup.s
+++ b/embed/boardloader/startup.s
@@ -55,7 +55,6 @@ reset_handler:
   // enter the application code
   bl main
 
-  // loop forever if the application code returns
-  b .
+  b shutdown
 
   .end


### PR DESCRIPTION
The peripherals used, especially, but not limited to, the display, preclude level 6 and 7 on my dev board. The risk of enabling this detector, and continuing to use the BOR level 3 option byte, is that they affect regular users (maybe longer USB cables, bad USB ports, etc... causing voltages closer to the thresholds). The reason to enable these thresholds is to provide a level of defense against voltage glitching attacks, and/or poorly functioning components (similar to the CSS does for the HSE clock).

Level 5 seems to work for me. I tested the regular startup and also a boardloader microSD reflash.
Level 7 trips in the boardloader for me while wiping the USB HS memory. Level 6 trips in the firmware while drawing the initial screen (if it doesn't then try an all white trezor logo with full backlight and see if it does).

I left the `PVD_IRQHandler` mapped to `default_handler` as the intent of this is to hinder voltage glitching attacks.

Side note: it maybe worthwhile profiling the power supply on actual devices to see how they hold up when full current draw is made in unison by the display, flash, cpu, etc..