### PR TITLE
bootloader: cleanup usb on firmware upload success before jumping to firmware

### DIFF
--- a/embed/bootloader/main.c
+++ b/embed/bootloader/main.c
@@ -226,6 +226,8 @@ bool bootloader_loop(void)
                     display_done(3); hal_delay(1000);
                     display_done(2); hal_delay(1000);
                     display_done(1); hal_delay(1000);
+                    usb_stop();
+                    usb_deinit();
                     display_fade(BACKLIGHT_NORMAL, 0, 500);
                     return true; // jump to firmware
                 }


### PR DESCRIPTION
This fixes the firmware hanging after successful upload by the bootloader.

Not sure if this is the best way to handle this, but it seems to work. Notably, this works best after the 3 second wait. Otherwise, IO read errors are encountered by `trezorctl`.

Tested with `lsusb` and `python-trezor> ./trezorctl firmware_update -f ../trezor-core/build/firmware/firmware.bin`