### PR TITLE
boardloader: production changes, flash option bytes, pvd level 5

### DIFF
--- a/embed/boardloader/lowlevel.c
+++ b/embed/boardloader/lowlevel.c
@@ -120,12 +120,13 @@ void periph_init(void)
     __HAL_RCC_GPIOD_CLK_ENABLE();
 
     // enable the PVD (programmable voltage detector).
-    // select the "2.6V" threshold (level 4).
+    // select the "2.7V" threshold (level 5). the typical electrical
+    // characteristic values are similar to BOR level 3.
     // this detector will be active regardless of the
     // flash option byte BOR setting.
     __HAL_RCC_PWR_CLK_ENABLE();
     PWR_PVDTypeDef pvd_config;
-    pvd_config.PVDLevel = PWR_PVDLEVEL_4;
+    pvd_config.PVDLevel = PWR_PVDLEVEL_5;
     pvd_config.Mode = PWR_PVD_MODE_IT_RISING_FALLING;
     HAL_PWR_ConfigPVD(&pvd_config);
     HAL_PWR_EnablePVD();

--- a/embed/boardloader/lowlevel.h
+++ b/embed/boardloader/lowlevel.h
@@ -1,11 +1,15 @@
-#ifndef __BOARDLOADER_LOWLEVEL_H__
-#define __BOARDLOADER_LOWLEVEL_H__
+#ifndef BOARDLOADER_LOWLEVEL_H
+#define BOARDLOADER_LOWLEVEL_H
 
 #include "secbool.h"
 
-void flash_set_option_bytes(void);
+uint32_t flash_wait_and_clear_status_flags(void);
 secbool flash_check_option_bytes(void);
+void flash_lock_option_bytes(void);
+void flash_unlock_option_bytes(void);
+uint32_t flash_set_option_bytes(void);
+secbool flash_configure_option_bytes(void);
 void periph_init(void);
 secbool reset_flags_init(void);
 
-#endif
+#endif // BOARDLOADER_LOWLEVEL_H

--- a/embed/boardloader/main.c
+++ b/embed/boardloader/main.c
@@ -146,23 +146,22 @@ static secbool copy_sdcard(void)
 
 int main(void)
 {
-    periph_init(); // need the systick timer running before the production flash (and many other HAL) operations
-
     if (sectrue != reset_flags_init()) {
         return 1;
     }
 
-#if PRODUCTION
-    flash_set_option_bytes();
-    if (sectrue != flash_check_option_bytes()) {
-        uint8_t sectors[] = {
+    // need the systick timer running before many HAL operations.
+    // want the PVD enabled before flash operations too.
+    periph_init();
+
+    if (sectrue != flash_configure_option_bytes()) {
+        const uint8_t sectors[] = {
             FLASH_SECTOR_STORAGE_1,
             FLASH_SECTOR_STORAGE_2,
         };
         flash_erase_sectors(sectors, 2, NULL);
         return 2;
     }
-#endif
 
     clear_otg_hs_memory();
 

--- a/embed/trezorhal/flash.c
+++ b/embed/trezorhal/flash.c
@@ -36,7 +36,7 @@ const uint32_t FLASH_SECTOR_TABLE[FLASH_SECTOR_COUNT + 1] = {
 secbool flash_unlock(void)
 {
     HAL_FLASH_Unlock();
-    __HAL_FLASH_CLEAR_FLAG(FLASH_FLAG_EOP | FLASH_FLAG_OPERR | FLASH_FLAG_WRPERR | FLASH_FLAG_PGAERR | FLASH_FLAG_PGPERR | FLASH_FLAG_PGSERR);
+    FLASH->SR |= FLASH_STATUS_ALL_FLAGS; // clear all status flags
     return sectrue;
 }
 

--- a/embed/trezorhal/flash.h
+++ b/embed/trezorhal/flash.h
@@ -1,5 +1,5 @@
-#ifndef __TREZORHAL_FLASH_H__
-#define __TREZORHAL_FLASH_H__
+#ifndef TREZORHAL_FLASH_H
+#define TREZORHAL_FLASH_H
 
 #include <stdint.h>
 #include "secbool.h"
@@ -40,9 +40,10 @@
 
 #define FLASH_SECTOR_COUNT 24
 
-extern const uint32_t FLASH_SECTOR_TABLE[FLASH_SECTOR_COUNT + 1];
+// note: FLASH_SR_RDERR is STM32F42xxx and STM32F43xxx specific (STM32F427) (reference RM0090 section 3.7.5)
+#define FLASH_STATUS_ALL_FLAGS (FLASH_SR_RDERR | FLASH_SR_PGSERR | FLASH_SR_PGPERR | FLASH_SR_PGAERR | FLASH_SR_WRPERR | FLASH_SR_SOP | FLASH_SR_EOP)
 
-void flash_set_option_bytes(void);
+extern const uint32_t FLASH_SECTOR_TABLE[FLASH_SECTOR_COUNT + 1];
 
 secbool flash_unlock(void);
 secbool flash_lock(void);
@@ -59,4 +60,4 @@ secbool flash_otp_write(uint8_t block, uint8_t offset, const uint8_t *data, uint
 secbool flash_otp_lock(uint8_t block);
 secbool flash_otp_is_locked(uint8_t block);
 
-#endif
+#endif // TREZORHAL_FLASH_H


### PR DESCRIPTION
Addressing a few things with this PR:

1. https://github.com/trezor/trezor-core/commit/311a28242b01a5617c0d4a940d6ba34ac55a2059
1. https://github.com/trezor/trezor-core/commit/16f657361c2565b6206816e0a456042f352f946b
1. https://github.com/trezor/trezor-core/commit/a08f18c2ce5b9e6518bf5fd7a989e0862d779975

I got the HAL version working, but noticed these things while doing it that made me think that what I'm proposing here is better:
1. HAL code does not actually check flash memory values
1. HAL flash code does not perform all recommended waits
1. HAL code depends on systick timer
1. HAL does not reset flash status flags

These changes also makes sure that the option byte code gets tested more as it is in the normal flow, and only a couple data values are different. I tested that setting the BOR, RDP (levels0 and 1), and WRP option bytes works.

There are a couple of subtle bug fixes mixed in.

I changed the header guards to not use reserved names.

There is a status flag addition for the 427 chip in `flash_unlock`.

Useful GDB debugging/testing commands for getting back to RDP level 0 from level 1:

```
// check FLASH->SR register
x/1xw 0x40023c0c

// check FLASH->OPTCR register
x/1xw 0x40023c14

// check FLASH->OPTCR1 register
x/1xw 0x40023c18

// unlock FLASH->OPTKEYR register
set * (unsigned int *) 0x40023c08 = 0x08192A3B
set * (unsigned int *) 0x40023c08 = 0x4C5D6E7F

// set defaults in FLASH->OPTCR1 register
set * (unsigned int *) 0x40023c18 = 0x0fff0000

// set defaults in FLASH->OPTCR register and commit changes to flash
set * (unsigned int *) 0x40023c14 = 0x0fffaaee

// check OPTION_BYTES_RDP_USER in flash memory
x/1xh 0x1fffc000

// check OPTION_BYTES_BANK1_WRP in flash memory
x/1xh 0x1fffc008

// check OPTION_BYTES_BANK2_WRP in flash memory
x/1xh 0x1ffec008
```