### PR TITLE
firmware: get_entropy text wrapping

### DIFF
--- a/src/apps/wallet/get_entropy.py
+++ b/src/apps/wallet/get_entropy.py
@@ -20,7 +20,7 @@ async def _show_entropy(ctx):
     from trezor.ui.container import Container
     from ..common.confirm import require_confirm
 
-    content = Container(
-        Text('Confirm entropy', ui.ICON_RESET, ui.MONO, 'Do you really want to send entropy?'))
-
-    await require_confirm(ctx, content, code=ProtectCall)
+    await require_confirm(ctx, Text(
+        'Confirm entropy', ui.ICON_RESET,
+        ui.BOLD, 'Do you really want', 'to send entropy?',
+        ui.NORMAL, 'Continue only if you', 'know what you are doing!'),code=ProtectCall)


### PR DESCRIPTION
testing with `trezorctl get_entropy 4` the text was going off screen.