### PR TITLE
embed/unix/usb.c: usb write fix

### DIFF
--- a/embed/unix/usb.c
+++ b/embed/unix/usb.c
@@ -106,7 +106,7 @@ int usb_hid_read(uint8_t iface_num, uint8_t *buf, uint32_t len) {
     static const char *ping_req = "PINGPING";
     static const char *ping_resp = "PONGPONG";
     if (r == strlen(ping_req) && memcmp(ping_req, buf, strlen(ping_req)) == 0) {
-        ensure(usb_hid_write(0, (const uint8_t *)ping_resp, strlen(ping_resp)), "usb_hid_write");
+        ensure(sectrue * (usb_hid_write(0, (const uint8_t *)ping_resp, strlen(ping_resp)) >= 0), "usb_hid_write");
         return 0;
     }
     return r;


### PR DESCRIPTION
Hi!

I've got some small assertion problem with `usb.c`. This PR fixes it. 

Pls take a look.

The problem:

```
FATAL ERROR:
expr: usb_hid_write(0, (const uint8_t *)ping_resp, strlen(ping_resp))
msg : usb_hid_write
file: embed/unix/usb.c:121
func: usb_hid_read
rev : 9c71bd8-dirty
SHUTDOWN
```
