### PR TITLE
webusb: avoid chrome http bug and nice side-effect of avoiding annoying notifications

### DIFF
--- a/embed/bootloader/bootui.c
+++ b/embed/bootloader/bootui.c
@@ -111,7 +111,8 @@ void ui_screen_third(void)
 {
     display_bar(0, 0, DISPLAY_RESX, DISPLAY_RESY, COLOR_WHITE);
     display_icon((DISPLAY_RESX - 180) / 2, (DISPLAY_RESY - 30) / 2, 180, 30, toi_icon_welcome + 12, sizeof(toi_icon_welcome) - 12, COLOR_BLACK, COLOR_WHITE);
-    display_text_center(120, 220, "Go to trezor.io/start", -1, FONT_NORMAL, COLOR_BLACK, COLOR_WHITE);
+    display_text_center(120, 200, "Go to", -1, FONT_NORMAL, COLOR_BLACK, COLOR_WHITE);
+    display_text_center(120, 220, "https://trezor.io/start", -1, FONT_NORMAL, COLOR_BLACK, COLOR_WHITE);
 }
 
 // info UI
@@ -136,7 +137,8 @@ void ui_screen_info(secbool buttons, const vendor_header * const vhdr, const ima
         display_text_center(120, 170, "Connect to host?", -1, FONT_NORMAL, COLOR_BLACK, COLOR_WHITE);
         ui_confirm_cancel_buttons();
     } else {
-        display_text_center(120, 220, "Go to trezor.io/start", -1, FONT_NORMAL, COLOR_BLACK, COLOR_WHITE);
+        display_text_center(120, 200, "Go to", -1, FONT_NORMAL, COLOR_BLACK, COLOR_WHITE);
+        display_text_center(120, 220, "https://trezor.io/start", -1, FONT_NORMAL, COLOR_BLACK, COLOR_WHITE);
     }
 }
 

--- a/embed/trezorhal/usb.c
+++ b/embed/trezorhal/usb.c
@@ -297,6 +297,7 @@ static uint8_t usb_class_deinit(USBD_HandleTypeDef *dev, uint8_t cfg_idx) {
 #define USB_WEBUSB_DESCRIPTOR_TYPE_URL  0x03
 #define USB_WEBUSB_URL_SCHEME_HTTP      0
 #define USB_WEBUSB_URL_SCHEME_HTTPS     1
+#define USB_WEBUSB_URL_SCHEME_ENTIRE    255
 
 static uint8_t usb_class_setup(USBD_HandleTypeDef *dev, USBD_SetupReqTypedef *req) {
     if (((req->bmRequest & USB_REQ_TYPE_MASK) != USB_REQ_TYPE_CLASS) &&
@@ -310,10 +311,10 @@ static uint8_t usb_class_setup(USBD_HandleTypeDef *dev, USBD_SetupReqTypedef *re
             if (sectrue == usb21_enabled && req->bRequest == USB_WEBUSB_VENDOR_CODE) {
                 if (req->wIndex == USB_WEBUSB_REQ_GET_URL && req->wValue == USB_WEBUSB_LANDING_PAGE) {
                     static const char webusb_url[] = {
-                        3 + 15,                             // uint8_t bLength
+                        3 + 23,                             // uint8_t bLength
                         USB_WEBUSB_DESCRIPTOR_TYPE_URL,     // uint8_t bDescriptorType
-                        USB_WEBUSB_URL_SCHEME_HTTPS,        // uint8_t bScheme
-                        't', 'r', 'e', 'z', 'o', 'r', '.', 'i', 'o', '/', 's', 't', 'a', 'r', 't',  // char URL[]
+                        USB_WEBUSB_URL_SCHEME_ENTIRE,        // uint8_t bScheme
+                        'h', 't', 't', 'p', 's', ':', '/', '/', 't', 'r', 'e', 'z', 'o', 'r', '.', 'i', 'o', '/', 's', 't', 'a', 'r', 't',  // char URL[]
                     };
                     USBD_CtlSendData(dev, UNCONST(webusb_url), MIN(req->wLength, sizeof(webusb_url)));
                     return USBD_OK;

--- a/src/apps/homescreen/homescreen.py
+++ b/src/apps/homescreen/homescreen.py
@@ -21,7 +21,7 @@ async def display_homescreen():
     from apps.common import storage
 
     if not storage.is_initialized():
-        label = 'Go to trezor.io/start'
+        label = 'https://trezor.io/start'
         image = None
     else:
         label = storage.get_label() or 'My TREZOR'


### PR DESCRIPTION
I was testing with the latest version of Chrome on a Ubuntu machine with Wireshark running.

When I plugged the device in, Chrome showed a notification. When I clicked on that notification, Chrome erroneously generated a plain HTTP request to http://trezor.io/start. This is a Chrome bug as it ignored the descriptor value being set to the HTTPS scheme (I verified the descriptor value with Wireshark listening on my USB bus also) (descriptor reference https://wicg.github.io/webusb/#webusb-descriptors). This bug is tied to Chrome's current cache status as well. So, clear your cache to easily reproduce.

This PR sets the scheme value to 255 which is supposed to encode the entire URL. This causes Chrome to neither show the notification, nor send a request. I'm fine with this because I thought that the notification was annoying anyways and at least it doesn't cause insecure requests to be processed by the browser.