### PR TITLE
bootloader: fix process_msg_unknown remaining chunk calculation

### DIFF
--- a/embed/bootloader/messages.c
+++ b/embed/bootloader/messages.c
@@ -553,9 +553,15 @@ int process_msg_WipeDevice(uint8_t iface_num, uint32_t msg_size, uint8_t *buf)
 void process_msg_unknown(uint8_t iface_num, uint32_t msg_size, uint8_t *buf)
 {
     // consume remaining message
-    int remaining_chunks = (msg_size - (USB_PACKET_SIZE - MSG_HEADER1_LEN)) / (USB_PACKET_SIZE - MSG_HEADER2_LEN);
+    int remaining_chunks = 0;
+
+    if (msg_size > (USB_PACKET_SIZE - MSG_HEADER1_LEN)) {
+        // calculate how many blocks need to be read to drain the message (rounded up to not leave any behind)
+        remaining_chunks = (msg_size - (USB_PACKET_SIZE - MSG_HEADER1_LEN) + ((USB_PACKET_SIZE - MSG_HEADER2_LEN) - 1)) / (USB_PACKET_SIZE - MSG_HEADER2_LEN);
+    }
+
     for (int i = 0; i < remaining_chunks; i++) {
-        int r = usb_webusb_read_blocking(USB_IFACE_NUM, buf, USB_PACKET_SIZE, USB_TIMEOUT);
+        int r = usb_webusb_read_blocking(iface_num, buf, USB_PACKET_SIZE, USB_TIMEOUT);
         ensure(sectrue * (r == USB_PACKET_SIZE), NULL);
     }
 

--- a/embed/bootloader/messages.c
+++ b/embed/bootloader/messages.c
@@ -552,19 +552,6 @@ int process_msg_WipeDevice(uint8_t iface_num, uint32_t msg_size, uint8_t *buf)
 
 void process_msg_unknown(uint8_t iface_num, uint32_t msg_size, uint8_t *buf)
 {
-    // consume remaining message
-    int remaining_chunks = 0;
-
-    if (msg_size > (USB_PACKET_SIZE - MSG_HEADER1_LEN)) {
-        // calculate how many blocks need to be read to drain the message (rounded up to not leave any behind)
-        remaining_chunks = (msg_size - (USB_PACKET_SIZE - MSG_HEADER1_LEN) + ((USB_PACKET_SIZE - MSG_HEADER2_LEN) - 1)) / (USB_PACKET_SIZE - MSG_HEADER2_LEN);
-    }
-
-    for (int i = 0; i < remaining_chunks; i++) {
-        int r = usb_webusb_read_blocking(iface_num, buf, USB_PACKET_SIZE, USB_TIMEOUT);
-        ensure(sectrue * (r == USB_PACKET_SIZE), NULL);
-    }
-
     MSG_SEND_INIT(Failure);
     MSG_SEND_ASSIGN_VALUE(code, FailureType_Failure_UnexpectedMessage);
     MSG_SEND_ASSIGN_STRING(message, "Unexpected message");


### PR DESCRIPTION
I was getting a red screen in the bootloader when I sent the unknown/invalid message `reset_device`. The message size, 22 was less than 55, and thus wrapping around to a large unsigned int. Also, the calculation was not rounding up to process all bytes. Finally, I made a small change to actually use the `iface_num` argument. I have not checked to see if a similar bug is in the firmware, but I'll look and open a separate PR if I find one.

I verified that this patch works against these tests that send messages having 1, 2, and 3 chunks:

```
python2 trezorctl reset_device

python2 trezorctl load_device -m 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'

python2 trezorctl load_device -m 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon agent'
```