### PR TITLE
Making bigger heapsize

### DIFF
--- a/emu.sh
+++ b/emu.sh
@@ -7,9 +7,9 @@ OPTLEVEL="${OPTLEVEL:-1}"
 MAIN="${MAIN:-main.py}"
 BROWSER="${BROWSER:-chromium}"
 if file $EXE | grep -q 80386 ; then
-HEAPSIZE="${HEAPSIZE:-170K}"
+HEAPSIZE="${HEAPSIZE:-800K}"
 else
-HEAPSIZE="${HEAPSIZE:-340K}"
+HEAPSIZE="${HEAPSIZE:-800K}"
 fi
 
 ARGS="-O${OPTLEVEL} -X heapsize=${HEAPSIZE}"


### PR DESCRIPTION
With current heapsize, emulator constantly fails; I made it 800k and it worked.

It is not scientific, I just increased the number and webwallet (with trezord-go from master) started to work.