### PR TITLE
embed/unix: emit TOUCH_END when mouse leaves active area.

### DIFF
--- a/embed/unix/touch.c
+++ b/embed/unix/touch.c
@@ -42,7 +42,15 @@ uint32_t touch_read(void)
             case SDL_MOUSEBUTTONUP:
                 x = event.button.x - sdl_touch_offset_x;
                 y = event.button.y - sdl_touch_offset_y;
-                if (x < 0 || y < 0 || x >= sdl_display_res_x || y >= sdl_display_res_y) break;
+                if (x < 0 || y < 0 || x >= sdl_display_res_x || y >= sdl_display_res_y) {
+                    if (event.motion.state) {
+                        int clamp_x = (x < 0) ? 0 : ((x >= sdl_display_res_x) ? sdl_display_res_x - 1 : x);
+                        int clamp_y = (y < 0) ? 0 : ((y >= sdl_display_res_y) ? sdl_display_res_y - 1 : y);
+                        return TOUCH_END | touch_pack_xy(clamp_x, clamp_y);
+                    } else {
+                        break;
+                    }
+                }
                 switch (event.type) {
                     case SDL_MOUSEBUTTONDOWN:
                         return TOUCH_START | touch_pack_xy(x, y);


### PR DESCRIPTION
This fixes the "swiping bug", swiping in emulator now feels more natural.