### PR TITLE
Ethereum: Fix fee computation.

### DIFF
--- a/src/apps/ethereum/layout.py
+++ b/src/apps/ethereum/layout.py
@@ -24,10 +24,10 @@ async def require_confirm_tx(ctx, to, value, chain_id, token=None):
 async def require_confirm_fee(ctx, spending, gas_price, gas_limit, chain_id, token=None):
     content = Text('Confirm transaction', ui.ICON_SEND,
                    ui.BOLD, format_ethereum_amount(spending, token, chain_id),
-                   ui.NORMAL, 'Gas:',
-                   ui.BOLD, format_ethereum_amount(gas_price, token, chain_id),
-                   ui.NORMAL, 'Limit:',
-                   ui.BOLD, format_ethereum_amount(gas_limit, token, chain_id),
+                   ui.NORMAL, 'Gas price:',
+                   ui.BOLD, format_ethereum_amount(gas_price, None, chain_id),
+                   ui.NORMAL, 'Maximum fee:',
+                   ui.BOLD, format_ethereum_amount(gas_price * gas_limit, None, chain_id),
                    icon_color=ui.GREEN)
     await require_hold_to_confirm(ctx, content, ButtonRequestType.SignTx)
 
@@ -52,7 +52,6 @@ def split_address(address):
 
 
 def format_ethereum_amount(value, token, chain_id):
-    value = int.from_bytes(value, 'big')
     if token:
         suffix = token[2]
         decimals = token[3]

--- a/src/trezor/crypto/rlp.py
+++ b/src/trezor/crypto/rlp.py
@@ -22,7 +22,7 @@ def encode_length(l: int, is_list: bool) -> bytes:
 
 def encode(data, include_length=True) -> bytes:
     if isinstance(data, int):
-        return encode(int_to_bytes(data))
+        data = int_to_bytes(data)
     if isinstance(data, bytearray):
         data = bytes(data)
     if isinstance(data, bytes):


### PR DESCRIPTION
- Gas is always in ether, even when sending tokens.
- Fee is computed by multiplying gas limit with gas price.
- Parse numbers already in sign_tx.
- Made rlp.encode non-recursive (also fixes not passing include_length).