### PR TITLE
scons: use env.Program() to build micropython emulator

### DIFF
--- a/SConscript.unix
+++ b/SConscript.unix
@@ -239,7 +239,7 @@ env.Replace(
     AS='as',
     AR='ar',
     CC='gcc',
-    LINK='ld',
+    LINK='gcc',
     SIZE='size',
     STRIP='strip',
     OBJCOPY='objcopy', )
@@ -332,7 +332,4 @@ obj_program += env.Object(
 
 env.Depends(obj_program, qstr_generated)
 
-program = env.Command(
-    target='micropython',
-    source=obj_program,
-    action='$CC -o $TARGET $SOURCES $_LIBDIRFLAGS $_LIBFLAGS $LINKFLAGS', )
+env.Program('micropython', obj_program)


### PR DESCRIPTION
Currently, running `make clean build_unix` fails with the following [error](https://gist.github.com/romanz/3c7fe9fa80b9fe02fe2151216a2910ff#file-build_fail-txt-L239) (it seems to create `build/unix/micropython` as a directory, failing the final linking stage of the buid).