### PR TITLE
replace mp_obj_get_int_truncated with mp_obj_int_get_checked

### DIFF
--- a/embed/extmod/modtrezorcrypto/modtrezorcrypto-random.h
+++ b/embed/extmod/modtrezorcrypto/modtrezorcrypto-random.h
@@ -26,7 +26,7 @@
 ///     Compute uniform random number from interval 0 ... n - 1.
 ///     '''
 STATIC mp_obj_t mod_trezorcrypto_random_uniform(mp_obj_t n) {
-    uint32_t nn = mp_obj_get_int_truncated(n);
+    uint32_t nn = mp_obj_int_get_checked(n);
     if (nn == 0) {
         mp_raise_ValueError("Maximum can't be zero");
     }


### PR DESCRIPTION
I strongly recommend you change `mp_obj_get_int_truncated` into `mp_obj_int_get_checked` in
`modtrezorcrypto-random.h` [on line 29.](https://github.com/trezor/trezor-core/blob/14b0d4439a2f348d3e25ab2b5a4e01babe6363dd/embed/extmod/modtrezorcrypto/modtrezorcrypto-random.h#L29)

Because otherwise, `modtrezorcrypto.random.uniform((2*32)+1)` will always return zero.

Similarly, any call with an argument larger than 2**32 will not do what you want.

I couldn't find any codepaths where that could happen under control of an attacker, but it's quite possible there is one, or could be someday.
