### PR TITLE
use pipenv to run python-trezor testsuite reproducibly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,15 +29,10 @@ addons:
     - python3-pip
 
 before_install:
-    - pip3 install --user --upgrade pip setuptools wheel
+    - pip3 install --user pipenv
 
 install:
-    - pip3 install --user scons
-    - pip3 install --user flake8
-    - pip3 install --user pytest
-    - pip3 install --user ecdsa mnemonic requests
-    - pip3 install --user click pyblake2 rlp
-    - pip3 install --user --no-deps git+https://github.com/trezor/python-trezor@master
+    - pipenv install
 
 before_script:
     - test "$GOAL" != "stm32" || wget https://developer.arm.com/-/media/Files/downloads/gnu-rm/$TOOLCHAIN_SHORTVER/$TOOLCHAIN_LONGVER-linux.tar.bz2
@@ -45,16 +40,16 @@ before_script:
     - test "$GOAL" != "stm32" || export PATH=$PWD/$TOOLCHAIN_LONGVER/bin:$PATH
 
 script:
-  - test "$GOAL" != "stm32" || make build_cross
-  - test "$GOAL" != "stm32" || make build_boardloader
-  - test "$GOAL" != "stm32" || make build_bootloader
-  - test "$GOAL" != "stm32" || make build_prodtest
-  - test "$GOAL" != "stm32" || make build_firmware
-  - test "$GOAL" != "stm32" || make sizecheck
+  - test "$GOAL" != "stm32" || pipenv run make build_cross
+  - test "$GOAL" != "stm32" || pipenv run make build_boardloader
+  - test "$GOAL" != "stm32" || pipenv run make build_bootloader
+  - test "$GOAL" != "stm32" || pipenv run make build_prodtest
+  - test "$GOAL" != "stm32" || pipenv run make build_firmware
+  - test "$GOAL" != "stm32" || pipenv run make sizecheck
 
-  - test "$GOAL" != "unix" || make build_unix_noui
-  - test "$GOAL" != "unix" || make test
-  - test "$GOAL" != "unix" || make test_emu
+  - test "$GOAL" != "unix" || pipenv run make build_unix_noui
+  - test "$GOAL" != "unix" || pipenv run make test
+  - test "$GOAL" != "unix" || pipenv run make test_emu
 
   # - test "$GOAL" != "src" || make style
 

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,10 @@
+[[source]]
+url = "https://pypi.org/simple"
+name = "pypi"
+verify_ssl = true
+
+[packages]
+trezor = {git = "https://github.com/trezor/python-trezor", editable = true, ref = "master"}
+rlp = "==0.6.0"
+pytest = "*"
+mock = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,186 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "b8bf327eb7717ec697cd92c17cd867494982b4e775c81897c51843b5f90953c0"
+        },
+        "pipfile-spec": 6,
+        "requires": {},
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "attrs": {
+            "hashes": [
+                "sha256:1c7960ccfd6a005cd9f7ba884e6316b5e430a3f1a6c37c5f87d8b43f83b54ec9",
+                "sha256:a17a9573a6f475c99b551c0e0a812707ddda1ec9653bed04c13841404ed6f450"
+            ],
+            "version": "==17.4.0"
+        },
+        "certifi": {
+            "hashes": [
+                "sha256:13e698f54293db9f89122b0581843a782ad0934a4fe0172d2a980ba77fc61bb7",
+                "sha256:9fa520c1bacfb634fa7af20a76bcbd3d5fb390481724c597da32c719a7dca4b0"
+            ],
+            "version": "==2018.4.16"
+        },
+        "chardet": {
+            "hashes": [
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+            ],
+            "version": "==3.0.4"
+        },
+        "click": {
+            "hashes": [
+                "sha256:29f99fc6125fbc931b758dc053b3114e55c77a6e4c6c3a2674a2dc986016381d",
+                "sha256:f15516df478d5a56180fbf80e68f206010e6d160fc39fa508b65e035fd75130b"
+            ],
+            "version": "==6.7"
+        },
+        "ecdsa": {
+            "hashes": [
+                "sha256:40d002cf360d0e035cf2cb985e1308d41aaa087cbfc135b2dc2d844296ea546c",
+                "sha256:64cf1ee26d1cde3c73c6d7d107f835fed7c6a2904aef9eac223d57ad800c43fa"
+            ],
+            "version": "==0.13"
+        },
+        "hidapi": {
+            "hashes": [
+                "sha256:1ac170f4d601c340f2cd52fd06e85c5e77bad7ceac811a7bb54b529f7dc28c24",
+                "sha256:8d3be666f464347022e2b47caf9132287885d9eacc7895314fc8fefcb4e42946",
+                "sha256:b4b1f6aff0192e9be153fe07c1b7576cb7a1ff52e78e3f76d867be95301a8e87",
+                "sha256:bf03f06f586ce7d8aeb697a94b7dba12dc9271aae92d7a8d4486360ff711a660",
+                "sha256:c76de162937326fcd57aa399f94939ce726242323e65c15c67e183da1f6c26f7",
+                "sha256:d4ad1e46aef98783a9e6274d523b8b1e766acfc3d72828cd44a337564d984cfa",
+                "sha256:d4b5787a04613503357606bb10e59c3e2c1114fa00ee328b838dd257f41cbd7b",
+                "sha256:e0be1aa6566979266a8fc845ab0e18613f4918cf2c977fe67050f5dc7e2a9a97",
+                "sha256:edfb16b16a298717cf05b8c8a9ad1828b6ff3de5e93048ceccd74e6ae4ff0922"
+            ],
+            "version": "==0.7.99.post21"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:2c6a5de3089009e3da7c5dde64a141dbc8551d5b7f6cf4ed7c2568d0cc520a8f",
+                "sha256:8c7309c718f94b3a625cb648ace320157ad16ff131ae0af362c9f21b80ef6ec4"
+            ],
+            "version": "==2.6"
+        },
+        "libusb1": {
+            "hashes": [
+                "sha256:8c930d9c1d037d9c83924c82608aa6a1adcaa01ca0e4a23ee0e8e18d7eee670d"
+            ],
+            "version": "==1.6.4"
+        },
+        "mnemonic": {
+            "hashes": [
+                "sha256:02a7306a792370f4a0c106c2cf1ce5a0c84b9dbd7e71c6792fdb9ad88a727f1d"
+            ],
+            "version": "==0.18"
+        },
+        "mock": {
+            "hashes": [
+                "sha256:5ce3c71c5545b472da17b72268978914d0252980348636840bd34a00b5cc96c1",
+                "sha256:b158b6df76edd239b8208d481dc46b6afd45a846b7812ff0ce58971cf5bc8bba"
+            ],
+            "index": "pypi",
+            "version": "==2.0.0"
+        },
+        "more-itertools": {
+            "hashes": [
+                "sha256:0dd8f72eeab0d2c3bd489025bb2f6a1b8342f9b198f6fc37b52d15cfa4531fea",
+                "sha256:11a625025954c20145b37ff6309cd54e39ca94f72f6bb9576d1195db6fa2442e",
+                "sha256:c9ce7eccdcb901a2c75d326ea134e0886abfbea5f93e91cc95de9507c0816c44"
+            ],
+            "version": "==4.1.0"
+        },
+        "pbkdf2": {
+            "hashes": [
+                "sha256:ac6397369f128212c43064a2b4878038dab78dab41875364554aaf2a684e6979"
+            ],
+            "version": "==1.3"
+        },
+        "pbr": {
+            "hashes": [
+                "sha256:4e8a0ed6a8705a26768f4c3da26026013b157821fe5f95881599556ea9d91c19",
+                "sha256:dae4aaa78eafcad10ce2581fc34d694faa616727837fd8e55c1a00951ad6744f"
+            ],
+            "version": "==4.0.2"
+        },
+        "pluggy": {
+            "hashes": [
+                "sha256:7f8ae7f5bdf75671a718d2daf0a64b7885f74510bcd98b1a0bb420eb9a9d0cff",
+                "sha256:d345c8fe681115900d6da8d048ba67c25df42973bda370783cd58826442dcd7c",
+                "sha256:e160a7fcf25762bb60efc7e171d4497ff1d8d2d75a3d0df7a21b76821ecbf5c5"
+            ],
+            "version": "==0.6.0"
+        },
+        "py": {
+            "hashes": [
+                "sha256:29c9fab495d7528e80ba1e343b958684f4ace687327e6f789a94bf3d1915f881",
+                "sha256:983f77f3331356039fdd792e9220b7b8ee1aa6bd2b25f567a963ff1de5a64f6a"
+            ],
+            "version": "==1.5.3"
+        },
+        "pyblake2": {
+            "hashes": [
+                "sha256:3757f7ad709b0e1b2a6b3919fa79fe3261f166fc375cd521f2be480f8319dde9",
+                "sha256:407e02c7f8f36fcec1b7aa114ddca0c1060c598142ea6f6759d03710b946a7e3",
+                "sha256:4d47b4a2c1d292b1e460bde1dda4d13aa792ed2ed70fcc263b6bc24632c8e902",
+                "sha256:5ccc7eb02edb82fafb8adbb90746af71460fbc29aa0f822526fc976dff83e93f",
+                "sha256:8043267fbc0b2f3748c6920591cd0b8b5609dcce60c504c32858aa36206386f2",
+                "sha256:982295a87907d50f4723db6bc724660da76b6547826d52160171d54f95b919ac",
+                "sha256:baa2190bfe549e36163aa44664d4ee3a9080b236fc5d42f50dc6fd36bbdc749e",
+                "sha256:c53417ee0bbe77db852d5fd1036749f03696ebc2265de359fe17418d800196c4",
+                "sha256:fbc9fcde75713930bc2a91b149e97be2401f7c9c56d735b46a109210f58d7358"
+            ],
+            "version": "==1.1.2"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:54713b26c97538db6ff0703a12b19aeaeb60b5e599de542e7fca0ec83b9038e8",
+                "sha256:829230122facf05a5f81a6d4dfe6454a04978ea3746853b2b84567ecf8e5c526"
+            ],
+            "index": "pypi",
+            "version": "==3.5.1"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:6a1b267aa90cac58ac3a765d067950e7dbbf75b1da07e895d1f594193a40a38b",
+                "sha256:9c443e7324ba5b85070c4a818ade28bfabedf16ea10206da1132edaa6dda237e"
+            ],
+            "version": "==2.18.4"
+        },
+        "rlp": {
+            "hashes": [
+                "sha256:87879a0ba1479b760cee98af165de2eee95258b261faa293199f60742be96f34"
+            ],
+            "index": "pypi",
+            "version": "==0.6.0"
+        },
+        "six": {
+            "hashes": [
+                "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9",
+                "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb"
+            ],
+            "version": "==1.11.0"
+        },
+        "trezor": {
+            "editable": true,
+            "git": "https://github.com/trezor/python-trezor",
+            "ref": "master"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:06330f386d6e4b195fbfc736b297f58c5a892e4440e54d294d7004e3a9bbea1b",
+                "sha256:cc44da8e1145637334317feebd728bd869a35285b93cbb4cca2577da7e62db4f"
+            ],
+            "version": "==1.22"
+        }
+    },
+    "develop": {}
+}

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ It runs both inside of the device and also in the TREZOR Emulator.
 
 * [API](docs/api.md)
 * [Build instructions](docs/build.md)
+* [Testing](docs/testing.md)
 * [Bootloader](docs/bootloader.md)
 * [Hardware](docs/hardware.md)
 * [Memory Layout](docs/memory.md)

--- a/docs/build.md
+++ b/docs/build.md
@@ -9,92 +9,78 @@ git clone --recursive https://github.com/trezor/trezor-core.git
 cd trezor-core
 ```
 
-If are building the already cloned the project, don't forget to use the following to refresh the submodules:
+If you are building from an existing checkout, don't forget to use the following to refresh the submodules:
 
 ```sh
 make vendor
 ```
 
-### Linux
+Install the required packages, depending on your operating system.
+* __Debian/Ubuntu__:
+  ```sh
+  sudo dpkg --add-architecture i386
+  sudo apt-get update
+  sudo apt-get install scons libsdl2-dev:i386 libsdl2-image-dev:i386 gcc-multilib
+  ```
+* __Fedora__:
+  ```sh
+  sudo yum install scons SDL2-devel.i686 SDL2_image-devel.i686
+  ```
+* __OpenSUSE__:
+  ```sh
+  sudo zypper install scons libSDL2-devel-32bit libSDL2_image-devel-32bit
+  ```
+* __Arch__:
+  ```sh
+  sudo pacman -S gcc-multilib scons lib32-sdl2 lib32-sdl2_image
+  ```
+* __Mac OS X__:
+  ```sh
+  brew install scons sdl2 sdl2_image
+  ```
+* __Windows__: not supported yet, sorry.
 
-#### Debian/Ubuntu
 
+Run the build with:
 ```sh
-sudo pip3 install --no-cache-dir pyblake2
-
-sudo dpkg --add-architecture i386
-sudo apt-get update
-sudo apt-get install scons libsdl2-dev:i386 libsdl2-image-dev:i386 gcc-multilib
-
 make build_unix
 ```
 
-#### Fedora
-
+Now you can start the emulator:
 ```sh
-sudo pip3 install --no-cache-dir pyblake2
-
-sudo yum install scons SDL2-devel.i686 SDL2_image-devel.i686
-
-make build_unix
+./emu.sh
 ```
-
-#### openSUSE
-
-```sh
-sudo pip3 install --no-cache-dir pyblake2
-
-sudo zypper install scons libSDL2-devel-32bit libSDL2_image-devel-32bit
-
-make build_unix
-```
-
-#### Arch
-
-```sh
-sudo pip3 install --no-cache-dir pyblake2
-
-sudo pacman -S gcc-multilib scons lib32-sdl2 lib32-sdl2_image
-
-make build_unix
-```
-
-### OS X
-
-```sh
-pip3 install --no-cache-dir pyblake2
-
-brew install scons sdl2 sdl2_image
-
-make build_unix
-```
-
-### Windows
-
-Not supported yet ...
 
 ## Build instructions for Embedded (ARM port)
 
-### Linux
+### Requirements
 
-For flashing firmware to blank device (without bootloader) use `make flash`,
-or `make flash STLINK_VER=v2-1` if using a ST-LINK/V2.1 interface.
-You need to have OpenOCD installed.
+You will need the GCC ARM toolchain for building and OpenOCD for flashing to a device.
+You will also need Python dependencies for signing.
 
 #### Debian/Ubuntu
 
 ```sh
-sudo pip3 install --no-cache-dir click pyblake2 scons
-sudo pip3 install --no-deps git+https://github.com/trezor/python-trezor.git@master
-
 sudo apt-get install gcc-arm-none-eabi libnewlib-arm-none-eabi
-
-make vendor build_boardloader build_bootloader build_firmware
 ```
 
-### OS X
+#### OS X
 
 1. Download [gcc-arm-none-eabi](https://launchpad.net/gcc-arm-embedded/5.0/5-2016-q3-update/)
 2. Follow the [install instructions](https://launchpadlibrarian.net/287100883/readme.txt)
 3. To install OpenOCD, run `brew install open-ocd`
 4. Run `make vendor build_boardloader build_bootloader build_firmware`
+
+### Building
+
+```sh
+sudo pip3 install pipenv
+pipenv install
+pipenv run make vendor build_boardloader build_bootloader build_firmware
+```
+
+### Flashing
+
+For flashing firmware to blank device (without bootloader) use `make flash`,
+or `make flash STLINK_VER=v2-1` if using a ST-LINK/V2.1 interface.
+You need to have OpenOCD installed.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,63 @@
+# Testing
+
+## Testing with python-trezor
+
+Apart from the internal tests, Trezor core has a suite of integration tests in the [`python-trezor`](https://github.com/trezor/python-trezor) library. There are several ways to use that.
+
+### 1. Running the suite with pipenv
+
+[`pipenv`](https://docs.pipenv.org/) is a tool for making reproducible Python environments. Install it with:
+```sh
+sudo pip3 install pipenv
+```
+Inside `trezor-core` checkout, install the environment:
+```sh
+pipenv install
+```
+And run the automated tests:
+```sh
+pipenv run make test_emu
+```
+
+### 2. Developing new tests
+
+You will need a separate checkout of `python-trezor`. It's probably a good idea to do this outside the `trezor-core` directory:
+```sh
+git clone https://github.com/trezor/python-trezor
+```
+Prepare a virtual environment with all the requirements, and switch into it. Again, it's easiest to do this with `pipenv`:
+```sh
+cd python-trezor
+pipenv install -r requirements-dev.txt
+pipenv install -e .
+pipenv shell
+```
+Alternately, if you have an existing virtualenv, you can install python-trezor in "develop" mode:
+```sh
+python setup.py develop
+```
+
+If you want to test against the emulator, run it in a separate terminal from the `trezor-core` checkout directory:
+```sh
+OPTLEVEL=0 ./emu.sh
+```
+
+Find the device address and export it as an environment variable. For the emulator, this is:
+```sh
+export TREZOR_PATH="udp:127.0.0.1:21324"
+```
+(You can find other devices with `trezorctl list`.)
+
+Now you can run the test suite with:
+```sh
+pytest
+```
+
+You can place your own tests in `trezorlib/tests/device_tests`. See test style guide (TODO).
+
+If you only want to run a particular test, pick it with `-k <keyword>`:
+```sh
+pytest -k nem   # only runs tests that have "nem" in the name
+```
+If you have tests marked `xfail` (expected to fail) but you want to run them as usual, run `pytest --runxfail`
+If you want to see debugging information and protocol dumps, run with `-v`.


### PR DESCRIPTION
this freezes dependency versions (most importantly right now, `rlp` is frozen at 0.6.0 which is the last that supports Travis python3.4) so that third-party changes shouldn't break the builds anymore.

Along with some nice new docs about testing.