### PR TITLE
drop kwargs from protobuf generated messages

### DIFF
--- a/src/apps/common/coins.py
+++ b/src/apps/common/coins.py
@@ -1,4 +1,15 @@
-from trezor.messages.CoinType import CoinType
+from trezor.messages.CoinType import CoinType as CoinType_proto
+
+
+class CoinType(CoinType_proto):
+    """Subclass of the protobuf CoinType that holds additionals off-wire properties."""
+
+    def __init__(self, **kwargs):
+        # XXX this should take an explicit list of arguments
+        super().__init__()
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
 
 # the following list is generated using tools/codegen/gen_coins.py
 # do not edit manually!

--- a/src/trezor/messages/Address.py
+++ b/src/trezor/messages/Address.py
@@ -3,15 +3,13 @@ import protobuf as p
 
 
 class Address(p.MessageType):
+    MESSAGE_WIRE_TYPE = 30
     FIELDS = {
         1: ('address', p.UnicodeType, 0),  # required
     }
-    MESSAGE_WIRE_TYPE = 30
 
     def __init__(
         self,
-        address: str = None,
-        **kwargs
+        address: str = None
     ) -> None:
         self.address = address
-        super().__init__(**kwargs)

--- a/src/trezor/messages/ApplyFlags.py
+++ b/src/trezor/messages/ApplyFlags.py
@@ -3,15 +3,13 @@ import protobuf as p
 
 
 class ApplyFlags(p.MessageType):
+    MESSAGE_WIRE_TYPE = 28
     FIELDS = {
         1: ('flags', p.UVarintType, 0),
     }
-    MESSAGE_WIRE_TYPE = 28
 
     def __init__(
         self,
-        flags: int = None,
-        **kwargs
+        flags: int = None
     ) -> None:
         self.flags = flags
-        super().__init__(**kwargs)

--- a/src/trezor/messages/ApplySettings.py
+++ b/src/trezor/messages/ApplySettings.py
@@ -3,6 +3,7 @@ import protobuf as p
 
 
 class ApplySettings(p.MessageType):
+    MESSAGE_WIRE_TYPE = 25
     FIELDS = {
         1: ('language', p.UnicodeType, 0),
         2: ('label', p.UnicodeType, 0),
@@ -10,7 +11,6 @@ class ApplySettings(p.MessageType):
         4: ('homescreen', p.BytesType, 0),
         5: ('passphrase_source', p.UVarintType, 0),
     }
-    MESSAGE_WIRE_TYPE = 25
 
     def __init__(
         self,
@@ -18,12 +18,10 @@ class ApplySettings(p.MessageType):
         label: str = None,
         use_passphrase: bool = None,
         homescreen: bytes = None,
-        passphrase_source: int = None,
-        **kwargs
+        passphrase_source: int = None
     ) -> None:
         self.language = language
         self.label = label
         self.use_passphrase = use_passphrase
         self.homescreen = homescreen
         self.passphrase_source = passphrase_source
-        super().__init__(**kwargs)

--- a/src/trezor/messages/BackupDevice.py
+++ b/src/trezor/messages/BackupDevice.py
@@ -4,9 +4,3 @@ import protobuf as p
 
 class BackupDevice(p.MessageType):
     MESSAGE_WIRE_TYPE = 34
-
-    def __init__(
-        self,
-        **kwargs
-    ) -> None:
-        super().__init__(**kwargs)

--- a/src/trezor/messages/ButtonAck.py
+++ b/src/trezor/messages/ButtonAck.py
@@ -4,9 +4,3 @@ import protobuf as p
 
 class ButtonAck(p.MessageType):
     MESSAGE_WIRE_TYPE = 27
-
-    def __init__(
-        self,
-        **kwargs
-    ) -> None:
-        super().__init__(**kwargs)

--- a/src/trezor/messages/ButtonRequest.py
+++ b/src/trezor/messages/ButtonRequest.py
@@ -3,18 +3,16 @@ import protobuf as p
 
 
 class ButtonRequest(p.MessageType):
+    MESSAGE_WIRE_TYPE = 26
     FIELDS = {
         1: ('code', p.UVarintType, 0),
         2: ('data', p.UnicodeType, 0),
     }
-    MESSAGE_WIRE_TYPE = 26
 
     def __init__(
         self,
         code: int = None,
-        data: str = None,
-        **kwargs
+        data: str = None
     ) -> None:
         self.code = code
         self.data = data
-        super().__init__(**kwargs)

--- a/src/trezor/messages/Cancel.py
+++ b/src/trezor/messages/Cancel.py
@@ -4,9 +4,3 @@ import protobuf as p
 
 class Cancel(p.MessageType):
     MESSAGE_WIRE_TYPE = 20
-
-    def __init__(
-        self,
-        **kwargs
-    ) -> None:
-        super().__init__(**kwargs)

--- a/src/trezor/messages/ChangePin.py
+++ b/src/trezor/messages/ChangePin.py
@@ -3,15 +3,13 @@ import protobuf as p
 
 
 class ChangePin(p.MessageType):
+    MESSAGE_WIRE_TYPE = 4
     FIELDS = {
         1: ('remove', p.BoolType, 0),
     }
-    MESSAGE_WIRE_TYPE = 4
 
     def __init__(
         self,
-        remove: bool = None,
-        **kwargs
+        remove: bool = None
     ) -> None:
         self.remove = remove
-        super().__init__(**kwargs)

--- a/src/trezor/messages/CipherKeyValue.py
+++ b/src/trezor/messages/CipherKeyValue.py
@@ -8,6 +8,7 @@ if __debug__:
 
 
 class CipherKeyValue(p.MessageType):
+    MESSAGE_WIRE_TYPE = 23
     FIELDS = {
         1: ('address_n', p.UVarintType, p.FLAG_REPEATED),
         2: ('key', p.UnicodeType, 0),
@@ -17,7 +18,6 @@ class CipherKeyValue(p.MessageType):
         6: ('ask_on_decrypt', p.BoolType, 0),
         7: ('iv', p.BytesType, 0),
     }
-    MESSAGE_WIRE_TYPE = 23
 
     def __init__(
         self,
@@ -27,8 +27,7 @@ class CipherKeyValue(p.MessageType):
         encrypt: bool = None,
         ask_on_encrypt: bool = None,
         ask_on_decrypt: bool = None,
-        iv: bytes = None,
-        **kwargs
+        iv: bytes = None
     ) -> None:
         self.address_n = address_n if address_n is not None else []
         self.key = key
@@ -37,4 +36,3 @@ class CipherKeyValue(p.MessageType):
         self.ask_on_encrypt = ask_on_encrypt
         self.ask_on_decrypt = ask_on_decrypt
         self.iv = iv
-        super().__init__(**kwargs)

--- a/src/trezor/messages/CipheredKeyValue.py
+++ b/src/trezor/messages/CipheredKeyValue.py
@@ -3,15 +3,13 @@ import protobuf as p
 
 
 class CipheredKeyValue(p.MessageType):
+    MESSAGE_WIRE_TYPE = 48
     FIELDS = {
         1: ('value', p.BytesType, 0),
     }
-    MESSAGE_WIRE_TYPE = 48
 
     def __init__(
         self,
-        value: bytes = None,
-        **kwargs
+        value: bytes = None
     ) -> None:
         self.value = value
-        super().__init__(**kwargs)

--- a/src/trezor/messages/ClearSession.py
+++ b/src/trezor/messages/ClearSession.py
@@ -4,9 +4,3 @@ import protobuf as p
 
 class ClearSession(p.MessageType):
     MESSAGE_WIRE_TYPE = 24
-
-    def __init__(
-        self,
-        **kwargs
-    ) -> None:
-        super().__init__(**kwargs)

--- a/src/trezor/messages/CoinType.py
+++ b/src/trezor/messages/CoinType.py
@@ -29,8 +29,7 @@ class CoinType(p.MessageType):
         xprv_magic: int = None,
         segwit: bool = None,
         forkid: int = None,
-        force_bip143: bool = None,
-        **kwargs
+        force_bip143: bool = None
     ) -> None:
         self.coin_name = coin_name
         self.coin_shortcut = coin_shortcut
@@ -43,4 +42,3 @@ class CoinType(p.MessageType):
         self.segwit = segwit
         self.forkid = forkid
         self.force_bip143 = force_bip143
-        super().__init__(**kwargs)

--- a/src/trezor/messages/CosiCommit.py
+++ b/src/trezor/messages/CosiCommit.py
@@ -8,18 +8,16 @@ if __debug__:
 
 
 class CosiCommit(p.MessageType):
+    MESSAGE_WIRE_TYPE = 71
     FIELDS = {
         1: ('address_n', p.UVarintType, p.FLAG_REPEATED),
         2: ('data', p.BytesType, 0),
     }
-    MESSAGE_WIRE_TYPE = 71
 
     def __init__(
         self,
         address_n: List[int] = None,
-        data: bytes = None,
-        **kwargs
+        data: bytes = None
     ) -> None:
         self.address_n = address_n if address_n is not None else []
         self.data = data
-        super().__init__(**kwargs)

--- a/src/trezor/messages/CosiCommitment.py
+++ b/src/trezor/messages/CosiCommitment.py
@@ -3,18 +3,16 @@ import protobuf as p
 
 
 class CosiCommitment(p.MessageType):
+    MESSAGE_WIRE_TYPE = 72
     FIELDS = {
         1: ('commitment', p.BytesType, 0),
         2: ('pubkey', p.BytesType, 0),
     }
-    MESSAGE_WIRE_TYPE = 72
 
     def __init__(
         self,
         commitment: bytes = None,
-        pubkey: bytes = None,
-        **kwargs
+        pubkey: bytes = None
     ) -> None:
         self.commitment = commitment
         self.pubkey = pubkey
-        super().__init__(**kwargs)

--- a/src/trezor/messages/CosiSign.py
+++ b/src/trezor/messages/CosiSign.py
@@ -8,24 +8,22 @@ if __debug__:
 
 
 class CosiSign(p.MessageType):
+    MESSAGE_WIRE_TYPE = 73
     FIELDS = {
         1: ('address_n', p.UVarintType, p.FLAG_REPEATED),
         2: ('data', p.BytesType, 0),
         3: ('global_commitment', p.BytesType, 0),
         4: ('global_pubkey', p.BytesType, 0),
     }
-    MESSAGE_WIRE_TYPE = 73
 
     def __init__(
         self,
         address_n: List[int] = None,
         data: bytes = None,
         global_commitment: bytes = None,
-        global_pubkey: bytes = None,
-        **kwargs
+        global_pubkey: bytes = None
     ) -> None:
         self.address_n = address_n if address_n is not None else []
         self.data = data
         self.global_commitment = global_commitment
         self.global_pubkey = global_pubkey
-        super().__init__(**kwargs)

--- a/src/trezor/messages/CosiSignature.py
+++ b/src/trezor/messages/CosiSignature.py
@@ -3,15 +3,13 @@ import protobuf as p
 
 
 class CosiSignature(p.MessageType):
+    MESSAGE_WIRE_TYPE = 74
     FIELDS = {
         1: ('signature', p.BytesType, 0),
     }
-    MESSAGE_WIRE_TYPE = 74
 
     def __init__(
         self,
-        signature: bytes = None,
-        **kwargs
+        signature: bytes = None
     ) -> None:
         self.signature = signature
-        super().__init__(**kwargs)

--- a/src/trezor/messages/DebugLinkDecision.py
+++ b/src/trezor/messages/DebugLinkDecision.py
@@ -3,21 +3,19 @@ import protobuf as p
 
 
 class DebugLinkDecision(p.MessageType):
+    MESSAGE_WIRE_TYPE = 100
     FIELDS = {
         1: ('yes_no', p.BoolType, 0),
         2: ('up_down', p.BoolType, 0),
         3: ('input', p.UnicodeType, 0),
     }
-    MESSAGE_WIRE_TYPE = 100
 
     def __init__(
         self,
         yes_no: bool = None,
         up_down: bool = None,
-        input: str = None,
-        **kwargs
+        input: str = None
     ) -> None:
         self.yes_no = yes_no
         self.up_down = up_down
         self.input = input
-        super().__init__(**kwargs)

--- a/src/trezor/messages/DebugLinkFlashErase.py
+++ b/src/trezor/messages/DebugLinkFlashErase.py
@@ -3,15 +3,13 @@ import protobuf as p
 
 
 class DebugLinkFlashErase(p.MessageType):
+    MESSAGE_WIRE_TYPE = 113
     FIELDS = {
         1: ('sector', p.UVarintType, 0),
     }
-    MESSAGE_WIRE_TYPE = 113
 
     def __init__(
         self,
-        sector: int = None,
-        **kwargs
+        sector: int = None
     ) -> None:
         self.sector = sector
-        super().__init__(**kwargs)

--- a/src/trezor/messages/DebugLinkGetState.py
+++ b/src/trezor/messages/DebugLinkGetState.py
@@ -4,9 +4,3 @@ import protobuf as p
 
 class DebugLinkGetState(p.MessageType):
     MESSAGE_WIRE_TYPE = 101
-
-    def __init__(
-        self,
-        **kwargs
-    ) -> None:
-        super().__init__(**kwargs)

--- a/src/trezor/messages/DebugLinkLog.py
+++ b/src/trezor/messages/DebugLinkLog.py
@@ -3,21 +3,19 @@ import protobuf as p
 
 
 class DebugLinkLog(p.MessageType):
+    MESSAGE_WIRE_TYPE = 104
     FIELDS = {
         1: ('level', p.UVarintType, 0),
         2: ('bucket', p.UnicodeType, 0),
         3: ('text', p.UnicodeType, 0),
     }
-    MESSAGE_WIRE_TYPE = 104
 
     def __init__(
         self,
         level: int = None,
         bucket: str = None,
-        text: str = None,
-        **kwargs
+        text: str = None
     ) -> None:
         self.level = level
         self.bucket = bucket
         self.text = text
-        super().__init__(**kwargs)

--- a/src/trezor/messages/DebugLinkMemory.py
+++ b/src/trezor/messages/DebugLinkMemory.py
@@ -3,15 +3,13 @@ import protobuf as p
 
 
 class DebugLinkMemory(p.MessageType):
+    MESSAGE_WIRE_TYPE = 111
     FIELDS = {
         1: ('memory', p.BytesType, 0),
     }
-    MESSAGE_WIRE_TYPE = 111
 
     def __init__(
         self,
-        memory: bytes = None,
-        **kwargs
+        memory: bytes = None
     ) -> None:
         self.memory = memory
-        super().__init__(**kwargs)

--- a/src/trezor/messages/DebugLinkMemoryRead.py
+++ b/src/trezor/messages/DebugLinkMemoryRead.py
@@ -3,18 +3,16 @@ import protobuf as p
 
 
 class DebugLinkMemoryRead(p.MessageType):
+    MESSAGE_WIRE_TYPE = 110
     FIELDS = {
         1: ('address', p.UVarintType, 0),
         2: ('length', p.UVarintType, 0),
     }
-    MESSAGE_WIRE_TYPE = 110
 
     def __init__(
         self,
         address: int = None,
-        length: int = None,
-        **kwargs
+        length: int = None
     ) -> None:
         self.address = address
         self.length = length
-        super().__init__(**kwargs)

--- a/src/trezor/messages/DebugLinkMemoryWrite.py
+++ b/src/trezor/messages/DebugLinkMemoryWrite.py
@@ -3,21 +3,19 @@ import protobuf as p
 
 
 class DebugLinkMemoryWrite(p.MessageType):
+    MESSAGE_WIRE_TYPE = 112
     FIELDS = {
         1: ('address', p.UVarintType, 0),
         2: ('memory', p.BytesType, 0),
         3: ('flash', p.BoolType, 0),
     }
-    MESSAGE_WIRE_TYPE = 112
 
     def __init__(
         self,
         address: int = None,
         memory: bytes = None,
-        flash: bool = None,
-        **kwargs
+        flash: bool = None
     ) -> None:
         self.address = address
         self.memory = memory
         self.flash = flash
-        super().__init__(**kwargs)

--- a/src/trezor/messages/DebugLinkState.py
+++ b/src/trezor/messages/DebugLinkState.py
@@ -4,6 +4,7 @@ from .HDNodeType import HDNodeType
 
 
 class DebugLinkState(p.MessageType):
+    MESSAGE_WIRE_TYPE = 102
     FIELDS = {
         1: ('layout', p.BytesType, 0),
         2: ('pin', p.UnicodeType, 0),
@@ -17,7 +18,6 @@ class DebugLinkState(p.MessageType):
         10: ('recovery_word_pos', p.UVarintType, 0),
         11: ('reset_word_pos', p.UVarintType, 0),
     }
-    MESSAGE_WIRE_TYPE = 102
 
     def __init__(
         self,
@@ -31,8 +31,7 @@ class DebugLinkState(p.MessageType):
         reset_entropy: bytes = None,
         recovery_fake_word: str = None,
         recovery_word_pos: int = None,
-        reset_word_pos: int = None,
-        **kwargs
+        reset_word_pos: int = None
     ) -> None:
         self.layout = layout
         self.pin = pin
@@ -45,4 +44,3 @@ class DebugLinkState(p.MessageType):
         self.recovery_fake_word = recovery_fake_word
         self.recovery_word_pos = recovery_word_pos
         self.reset_word_pos = reset_word_pos
-        super().__init__(**kwargs)

--- a/src/trezor/messages/DebugLinkStop.py
+++ b/src/trezor/messages/DebugLinkStop.py
@@ -4,9 +4,3 @@ import protobuf as p
 
 class DebugLinkStop(p.MessageType):
     MESSAGE_WIRE_TYPE = 103
-
-    def __init__(
-        self,
-        **kwargs
-    ) -> None:
-        super().__init__(**kwargs)

--- a/src/trezor/messages/DecryptMessage.py
+++ b/src/trezor/messages/DecryptMessage.py
@@ -8,24 +8,22 @@ if __debug__:
 
 
 class DecryptMessage(p.MessageType):
+    MESSAGE_WIRE_TYPE = 51
     FIELDS = {
         1: ('address_n', p.UVarintType, p.FLAG_REPEATED),
         2: ('nonce', p.BytesType, 0),
         3: ('message', p.BytesType, 0),
         4: ('hmac', p.BytesType, 0),
     }
-    MESSAGE_WIRE_TYPE = 51
 
     def __init__(
         self,
         address_n: List[int] = None,
         nonce: bytes = None,
         message: bytes = None,
-        hmac: bytes = None,
-        **kwargs
+        hmac: bytes = None
     ) -> None:
         self.address_n = address_n if address_n is not None else []
         self.nonce = nonce
         self.message = message
         self.hmac = hmac
-        super().__init__(**kwargs)

--- a/src/trezor/messages/DecryptedMessage.py
+++ b/src/trezor/messages/DecryptedMessage.py
@@ -3,18 +3,16 @@ import protobuf as p
 
 
 class DecryptedMessage(p.MessageType):
+    MESSAGE_WIRE_TYPE = 52
     FIELDS = {
         1: ('message', p.BytesType, 0),
         2: ('address', p.UnicodeType, 0),
     }
-    MESSAGE_WIRE_TYPE = 52
 
     def __init__(
         self,
         message: bytes = None,
-        address: str = None,
-        **kwargs
+        address: str = None
     ) -> None:
         self.message = message
         self.address = address
-        super().__init__(**kwargs)

--- a/src/trezor/messages/ECDHSessionKey.py
+++ b/src/trezor/messages/ECDHSessionKey.py
@@ -3,15 +3,13 @@ import protobuf as p
 
 
 class ECDHSessionKey(p.MessageType):
+    MESSAGE_WIRE_TYPE = 62
     FIELDS = {
         1: ('session_key', p.BytesType, 0),
     }
-    MESSAGE_WIRE_TYPE = 62
 
     def __init__(
         self,
-        session_key: bytes = None,
-        **kwargs
+        session_key: bytes = None
     ) -> None:
         self.session_key = session_key
-        super().__init__(**kwargs)

--- a/src/trezor/messages/EncryptMessage.py
+++ b/src/trezor/messages/EncryptMessage.py
@@ -8,6 +8,7 @@ if __debug__:
 
 
 class EncryptMessage(p.MessageType):
+    MESSAGE_WIRE_TYPE = 49
     FIELDS = {
         1: ('pubkey', p.BytesType, 0),
         2: ('message', p.BytesType, 0),
@@ -15,7 +16,6 @@ class EncryptMessage(p.MessageType):
         4: ('address_n', p.UVarintType, p.FLAG_REPEATED),
         5: ('coin_name', p.UnicodeType, 0),  # default='Bitcoin'
     }
-    MESSAGE_WIRE_TYPE = 49
 
     def __init__(
         self,
@@ -23,12 +23,10 @@ class EncryptMessage(p.MessageType):
         message: bytes = None,
         display_only: bool = None,
         address_n: List[int] = None,
-        coin_name: str = None,
-        **kwargs
+        coin_name: str = None
     ) -> None:
         self.pubkey = pubkey
         self.message = message
         self.display_only = display_only
         self.address_n = address_n if address_n is not None else []
         self.coin_name = coin_name
-        super().__init__(**kwargs)

--- a/src/trezor/messages/EncryptedMessage.py
+++ b/src/trezor/messages/EncryptedMessage.py
@@ -3,21 +3,19 @@ import protobuf as p
 
 
 class EncryptedMessage(p.MessageType):
+    MESSAGE_WIRE_TYPE = 50
     FIELDS = {
         1: ('nonce', p.BytesType, 0),
         2: ('message', p.BytesType, 0),
         3: ('hmac', p.BytesType, 0),
     }
-    MESSAGE_WIRE_TYPE = 50
 
     def __init__(
         self,
         nonce: bytes = None,
         message: bytes = None,
-        hmac: bytes = None,
-        **kwargs
+        hmac: bytes = None
     ) -> None:
         self.nonce = nonce
         self.message = message
         self.hmac = hmac
-        super().__init__(**kwargs)

--- a/src/trezor/messages/Entropy.py
+++ b/src/trezor/messages/Entropy.py
@@ -3,15 +3,13 @@ import protobuf as p
 
 
 class Entropy(p.MessageType):
+    MESSAGE_WIRE_TYPE = 10
     FIELDS = {
         1: ('entropy', p.BytesType, 0),  # required
     }
-    MESSAGE_WIRE_TYPE = 10
 
     def __init__(
         self,
-        entropy: bytes = None,
-        **kwargs
+        entropy: bytes = None
     ) -> None:
         self.entropy = entropy
-        super().__init__(**kwargs)

--- a/src/trezor/messages/EntropyAck.py
+++ b/src/trezor/messages/EntropyAck.py
@@ -3,15 +3,13 @@ import protobuf as p
 
 
 class EntropyAck(p.MessageType):
+    MESSAGE_WIRE_TYPE = 36
     FIELDS = {
         1: ('entropy', p.BytesType, 0),
     }
-    MESSAGE_WIRE_TYPE = 36
 
     def __init__(
         self,
-        entropy: bytes = None,
-        **kwargs
+        entropy: bytes = None
     ) -> None:
         self.entropy = entropy
-        super().__init__(**kwargs)

--- a/src/trezor/messages/EntropyRequest.py
+++ b/src/trezor/messages/EntropyRequest.py
@@ -4,9 +4,3 @@ import protobuf as p
 
 class EntropyRequest(p.MessageType):
     MESSAGE_WIRE_TYPE = 35
-
-    def __init__(
-        self,
-        **kwargs
-    ) -> None:
-        super().__init__(**kwargs)

--- a/src/trezor/messages/EstimateTxSize.py
+++ b/src/trezor/messages/EstimateTxSize.py
@@ -3,21 +3,19 @@ import protobuf as p
 
 
 class EstimateTxSize(p.MessageType):
+    MESSAGE_WIRE_TYPE = 43
     FIELDS = {
         1: ('outputs_count', p.UVarintType, 0),  # required
         2: ('inputs_count', p.UVarintType, 0),  # required
         3: ('coin_name', p.UnicodeType, 0),  # default='Bitcoin'
     }
-    MESSAGE_WIRE_TYPE = 43
 
     def __init__(
         self,
         outputs_count: int = None,
         inputs_count: int = None,
-        coin_name: str = None,
-        **kwargs
+        coin_name: str = None
     ) -> None:
         self.outputs_count = outputs_count
         self.inputs_count = inputs_count
         self.coin_name = coin_name
-        super().__init__(**kwargs)

--- a/src/trezor/messages/EthereumAddress.py
+++ b/src/trezor/messages/EthereumAddress.py
@@ -3,15 +3,13 @@ import protobuf as p
 
 
 class EthereumAddress(p.MessageType):
+    MESSAGE_WIRE_TYPE = 57
     FIELDS = {
         1: ('address', p.BytesType, 0),  # required
     }
-    MESSAGE_WIRE_TYPE = 57
 
     def __init__(
         self,
-        address: bytes = None,
-        **kwargs
+        address: bytes = None
     ) -> None:
         self.address = address
-        super().__init__(**kwargs)

--- a/src/trezor/messages/EthereumGetAddress.py
+++ b/src/trezor/messages/EthereumGetAddress.py
@@ -8,18 +8,16 @@ if __debug__:
 
 
 class EthereumGetAddress(p.MessageType):
+    MESSAGE_WIRE_TYPE = 56
     FIELDS = {
         1: ('address_n', p.UVarintType, p.FLAG_REPEATED),
         2: ('show_display', p.BoolType, 0),
     }
-    MESSAGE_WIRE_TYPE = 56
 
     def __init__(
         self,
         address_n: List[int] = None,
-        show_display: bool = None,
-        **kwargs
+        show_display: bool = None
     ) -> None:
         self.address_n = address_n if address_n is not None else []
         self.show_display = show_display
-        super().__init__(**kwargs)

--- a/src/trezor/messages/EthereumMessageSignature.py
+++ b/src/trezor/messages/EthereumMessageSignature.py
@@ -3,18 +3,16 @@ import protobuf as p
 
 
 class EthereumMessageSignature(p.MessageType):
+    MESSAGE_WIRE_TYPE = 66
     FIELDS = {
         1: ('address', p.BytesType, 0),
         2: ('signature', p.BytesType, 0),
     }
-    MESSAGE_WIRE_TYPE = 66
 
     def __init__(
         self,
         address: bytes = None,
-        signature: bytes = None,
-        **kwargs
+        signature: bytes = None
     ) -> None:
         self.address = address
         self.signature = signature
-        super().__init__(**kwargs)

--- a/src/trezor/messages/EthereumSignMessage.py
+++ b/src/trezor/messages/EthereumSignMessage.py
@@ -8,18 +8,16 @@ if __debug__:
 
 
 class EthereumSignMessage(p.MessageType):
+    MESSAGE_WIRE_TYPE = 64
     FIELDS = {
         1: ('address_n', p.UVarintType, p.FLAG_REPEATED),
         2: ('message', p.BytesType, 0),  # required
     }
-    MESSAGE_WIRE_TYPE = 64
 
     def __init__(
         self,
         address_n: List[int] = None,
-        message: bytes = None,
-        **kwargs
+        message: bytes = None
     ) -> None:
         self.address_n = address_n if address_n is not None else []
         self.message = message
-        super().__init__(**kwargs)

--- a/src/trezor/messages/EthereumSignTx.py
+++ b/src/trezor/messages/EthereumSignTx.py
@@ -8,6 +8,7 @@ if __debug__:
 
 
 class EthereumSignTx(p.MessageType):
+    MESSAGE_WIRE_TYPE = 58
     FIELDS = {
         1: ('address_n', p.UVarintType, p.FLAG_REPEATED),
         2: ('nonce', p.BytesType, 0),
@@ -20,7 +21,6 @@ class EthereumSignTx(p.MessageType):
         9: ('chain_id', p.UVarintType, 0),
         10: ('tx_type', p.UVarintType, 0),
     }
-    MESSAGE_WIRE_TYPE = 58
 
     def __init__(
         self,
@@ -33,8 +33,7 @@ class EthereumSignTx(p.MessageType):
         data_initial_chunk: bytes = None,
         data_length: int = None,
         chain_id: int = None,
-        tx_type: int = None,
-        **kwargs
+        tx_type: int = None
     ) -> None:
         self.address_n = address_n if address_n is not None else []
         self.nonce = nonce
@@ -46,4 +45,3 @@ class EthereumSignTx(p.MessageType):
         self.data_length = data_length
         self.chain_id = chain_id
         self.tx_type = tx_type
-        super().__init__(**kwargs)

--- a/src/trezor/messages/EthereumTxAck.py
+++ b/src/trezor/messages/EthereumTxAck.py
@@ -3,15 +3,13 @@ import protobuf as p
 
 
 class EthereumTxAck(p.MessageType):
+    MESSAGE_WIRE_TYPE = 60
     FIELDS = {
         1: ('data_chunk', p.BytesType, 0),
     }
-    MESSAGE_WIRE_TYPE = 60
 
     def __init__(
         self,
-        data_chunk: bytes = None,
-        **kwargs
+        data_chunk: bytes = None
     ) -> None:
         self.data_chunk = data_chunk
-        super().__init__(**kwargs)

--- a/src/trezor/messages/EthereumTxRequest.py
+++ b/src/trezor/messages/EthereumTxRequest.py
@@ -3,24 +3,22 @@ import protobuf as p
 
 
 class EthereumTxRequest(p.MessageType):
+    MESSAGE_WIRE_TYPE = 59
     FIELDS = {
         1: ('data_length', p.UVarintType, 0),
         2: ('signature_v', p.UVarintType, 0),
         3: ('signature_r', p.BytesType, 0),
         4: ('signature_s', p.BytesType, 0),
     }
-    MESSAGE_WIRE_TYPE = 59
 
     def __init__(
         self,
         data_length: int = None,
         signature_v: int = None,
         signature_r: bytes = None,
-        signature_s: bytes = None,
-        **kwargs
+        signature_s: bytes = None
     ) -> None:
         self.data_length = data_length
         self.signature_v = signature_v
         self.signature_r = signature_r
         self.signature_s = signature_s
-        super().__init__(**kwargs)

--- a/src/trezor/messages/EthereumVerifyMessage.py
+++ b/src/trezor/messages/EthereumVerifyMessage.py
@@ -3,21 +3,19 @@ import protobuf as p
 
 
 class EthereumVerifyMessage(p.MessageType):
+    MESSAGE_WIRE_TYPE = 65
     FIELDS = {
         1: ('address', p.BytesType, 0),
         2: ('signature', p.BytesType, 0),
         3: ('message', p.BytesType, 0),
     }
-    MESSAGE_WIRE_TYPE = 65
 
     def __init__(
         self,
         address: bytes = None,
         signature: bytes = None,
-        message: bytes = None,
-        **kwargs
+        message: bytes = None
     ) -> None:
         self.address = address
         self.signature = signature
         self.message = message
-        super().__init__(**kwargs)

--- a/src/trezor/messages/Failure.py
+++ b/src/trezor/messages/Failure.py
@@ -3,18 +3,16 @@ import protobuf as p
 
 
 class Failure(p.MessageType):
+    MESSAGE_WIRE_TYPE = 3
     FIELDS = {
         1: ('code', p.UVarintType, 0),
         2: ('message', p.UnicodeType, 0),
     }
-    MESSAGE_WIRE_TYPE = 3
 
     def __init__(
         self,
         code: int = None,
-        message: str = None,
-        **kwargs
+        message: str = None
     ) -> None:
         self.code = code
         self.message = message
-        super().__init__(**kwargs)

--- a/src/trezor/messages/Features.py
+++ b/src/trezor/messages/Features.py
@@ -9,6 +9,7 @@ from .CoinType import CoinType
 
 
 class Features(p.MessageType):
+    MESSAGE_WIRE_TYPE = 17
     FIELDS = {
         1: ('vendor', p.UnicodeType, 0),
         2: ('major_version', p.UVarintType, 0),
@@ -38,7 +39,6 @@ class Features(p.MessageType):
         26: ('fw_vendor_keys', p.BytesType, 0),
         27: ('unfinished_backup', p.BoolType, 0),
     }
-    MESSAGE_WIRE_TYPE = 17
 
     def __init__(
         self,
@@ -68,8 +68,7 @@ class Features(p.MessageType):
         fw_patch: int = None,
         fw_vendor: str = None,
         fw_vendor_keys: bytes = None,
-        unfinished_backup: bool = None,
-        **kwargs
+        unfinished_backup: bool = None
     ) -> None:
         self.vendor = vendor
         self.major_version = major_version
@@ -98,4 +97,3 @@ class Features(p.MessageType):
         self.fw_vendor = fw_vendor
         self.fw_vendor_keys = fw_vendor_keys
         self.unfinished_backup = unfinished_backup
-        super().__init__(**kwargs)

--- a/src/trezor/messages/FirmwareErase.py
+++ b/src/trezor/messages/FirmwareErase.py
@@ -3,15 +3,13 @@ import protobuf as p
 
 
 class FirmwareErase(p.MessageType):
+    MESSAGE_WIRE_TYPE = 6
     FIELDS = {
         1: ('length', p.UVarintType, 0),
     }
-    MESSAGE_WIRE_TYPE = 6
 
     def __init__(
         self,
-        length: int = None,
-        **kwargs
+        length: int = None
     ) -> None:
         self.length = length
-        super().__init__(**kwargs)

--- a/src/trezor/messages/FirmwareRequest.py
+++ b/src/trezor/messages/FirmwareRequest.py
@@ -3,18 +3,16 @@ import protobuf as p
 
 
 class FirmwareRequest(p.MessageType):
+    MESSAGE_WIRE_TYPE = 8
     FIELDS = {
         1: ('offset', p.UVarintType, 0),
         2: ('length', p.UVarintType, 0),
     }
-    MESSAGE_WIRE_TYPE = 8
 
     def __init__(
         self,
         offset: int = None,
-        length: int = None,
-        **kwargs
+        length: int = None
     ) -> None:
         self.offset = offset
         self.length = length
-        super().__init__(**kwargs)

--- a/src/trezor/messages/FirmwareUpload.py
+++ b/src/trezor/messages/FirmwareUpload.py
@@ -3,18 +3,16 @@ import protobuf as p
 
 
 class FirmwareUpload(p.MessageType):
+    MESSAGE_WIRE_TYPE = 7
     FIELDS = {
         1: ('payload', p.BytesType, 0),  # required
         2: ('hash', p.BytesType, 0),
     }
-    MESSAGE_WIRE_TYPE = 7
 
     def __init__(
         self,
         payload: bytes = None,
-        hash: bytes = None,
-        **kwargs
+        hash: bytes = None
     ) -> None:
         self.payload = payload
         self.hash = hash
-        super().__init__(**kwargs)

--- a/src/trezor/messages/GetAddress.py
+++ b/src/trezor/messages/GetAddress.py
@@ -9,6 +9,7 @@ from .MultisigRedeemScriptType import MultisigRedeemScriptType
 
 
 class GetAddress(p.MessageType):
+    MESSAGE_WIRE_TYPE = 29
     FIELDS = {
         1: ('address_n', p.UVarintType, p.FLAG_REPEATED),
         2: ('coin_name', p.UnicodeType, 0),  # default='Bitcoin'
@@ -16,7 +17,6 @@ class GetAddress(p.MessageType):
         4: ('multisig', MultisigRedeemScriptType, 0),
         5: ('script_type', p.UVarintType, 0),  # default=0
     }
-    MESSAGE_WIRE_TYPE = 29
 
     def __init__(
         self,
@@ -24,12 +24,10 @@ class GetAddress(p.MessageType):
         coin_name: str = None,
         show_display: bool = None,
         multisig: MultisigRedeemScriptType = None,
-        script_type: int = None,
-        **kwargs
+        script_type: int = None
     ) -> None:
         self.address_n = address_n if address_n is not None else []
         self.coin_name = coin_name
         self.show_display = show_display
         self.multisig = multisig
         self.script_type = script_type
-        super().__init__(**kwargs)

--- a/src/trezor/messages/GetECDHSessionKey.py
+++ b/src/trezor/messages/GetECDHSessionKey.py
@@ -4,21 +4,19 @@ from .IdentityType import IdentityType
 
 
 class GetECDHSessionKey(p.MessageType):
+    MESSAGE_WIRE_TYPE = 61
     FIELDS = {
         1: ('identity', IdentityType, 0),
         2: ('peer_public_key', p.BytesType, 0),
         3: ('ecdsa_curve_name', p.UnicodeType, 0),
     }
-    MESSAGE_WIRE_TYPE = 61
 
     def __init__(
         self,
         identity: IdentityType = None,
         peer_public_key: bytes = None,
-        ecdsa_curve_name: str = None,
-        **kwargs
+        ecdsa_curve_name: str = None
     ) -> None:
         self.identity = identity
         self.peer_public_key = peer_public_key
         self.ecdsa_curve_name = ecdsa_curve_name
-        super().__init__(**kwargs)

--- a/src/trezor/messages/GetEntropy.py
+++ b/src/trezor/messages/GetEntropy.py
@@ -3,15 +3,13 @@ import protobuf as p
 
 
 class GetEntropy(p.MessageType):
+    MESSAGE_WIRE_TYPE = 9
     FIELDS = {
         1: ('size', p.UVarintType, 0),  # required
     }
-    MESSAGE_WIRE_TYPE = 9
 
     def __init__(
         self,
-        size: int = None,
-        **kwargs
+        size: int = None
     ) -> None:
         self.size = size
-        super().__init__(**kwargs)

--- a/src/trezor/messages/GetFeatures.py
+++ b/src/trezor/messages/GetFeatures.py
@@ -4,9 +4,3 @@ import protobuf as p
 
 class GetFeatures(p.MessageType):
     MESSAGE_WIRE_TYPE = 55
-
-    def __init__(
-        self,
-        **kwargs
-    ) -> None:
-        super().__init__(**kwargs)

--- a/src/trezor/messages/GetPublicKey.py
+++ b/src/trezor/messages/GetPublicKey.py
@@ -8,24 +8,22 @@ if __debug__:
 
 
 class GetPublicKey(p.MessageType):
+    MESSAGE_WIRE_TYPE = 11
     FIELDS = {
         1: ('address_n', p.UVarintType, p.FLAG_REPEATED),
         2: ('ecdsa_curve_name', p.UnicodeType, 0),
         3: ('show_display', p.BoolType, 0),
         4: ('coin_name', p.UnicodeType, 0),  # default='Bitcoin'
     }
-    MESSAGE_WIRE_TYPE = 11
 
     def __init__(
         self,
         address_n: List[int] = None,
         ecdsa_curve_name: str = None,
         show_display: bool = None,
-        coin_name: str = None,
-        **kwargs
+        coin_name: str = None
     ) -> None:
         self.address_n = address_n if address_n is not None else []
         self.ecdsa_curve_name = ecdsa_curve_name
         self.show_display = show_display
         self.coin_name = coin_name
-        super().__init__(**kwargs)

--- a/src/trezor/messages/HDNodePathType.py
+++ b/src/trezor/messages/HDNodePathType.py
@@ -17,9 +17,7 @@ class HDNodePathType(p.MessageType):
     def __init__(
         self,
         node: HDNodeType = None,
-        address_n: List[int] = None,
-        **kwargs
+        address_n: List[int] = None
     ) -> None:
         self.node = node
         self.address_n = address_n if address_n is not None else []
-        super().__init__(**kwargs)

--- a/src/trezor/messages/HDNodeType.py
+++ b/src/trezor/messages/HDNodeType.py
@@ -19,8 +19,7 @@ class HDNodeType(p.MessageType):
         child_num: int = None,
         chain_code: bytes = None,
         private_key: bytes = None,
-        public_key: bytes = None,
-        **kwargs
+        public_key: bytes = None
     ) -> None:
         self.depth = depth
         self.fingerprint = fingerprint
@@ -28,4 +27,3 @@ class HDNodeType(p.MessageType):
         self.chain_code = chain_code
         self.private_key = private_key
         self.public_key = public_key
-        super().__init__(**kwargs)

--- a/src/trezor/messages/IdentityType.py
+++ b/src/trezor/messages/IdentityType.py
@@ -19,8 +19,7 @@ class IdentityType(p.MessageType):
         host: str = None,
         port: str = None,
         path: str = None,
-        index: int = None,
-        **kwargs
+        index: int = None
     ) -> None:
         self.proto = proto
         self.user = user
@@ -28,4 +27,3 @@ class IdentityType(p.MessageType):
         self.port = port
         self.path = path
         self.index = index
-        super().__init__(**kwargs)

--- a/src/trezor/messages/Initialize.py
+++ b/src/trezor/messages/Initialize.py
@@ -3,15 +3,13 @@ import protobuf as p
 
 
 class Initialize(p.MessageType):
+    MESSAGE_WIRE_TYPE = 0
     FIELDS = {
         1: ('state', p.BytesType, 0),
     }
-    MESSAGE_WIRE_TYPE = 0
 
     def __init__(
         self,
-        state: bytes = None,
-        **kwargs
+        state: bytes = None
     ) -> None:
         self.state = state
-        super().__init__(**kwargs)

--- a/src/trezor/messages/LoadDevice.py
+++ b/src/trezor/messages/LoadDevice.py
@@ -4,6 +4,7 @@ from .HDNodeType import HDNodeType
 
 
 class LoadDevice(p.MessageType):
+    MESSAGE_WIRE_TYPE = 13
     FIELDS = {
         1: ('mnemonic', p.UnicodeType, 0),
         2: ('node', HDNodeType, 0),
@@ -14,7 +15,6 @@ class LoadDevice(p.MessageType):
         7: ('skip_checksum', p.BoolType, 0),
         8: ('u2f_counter', p.UVarintType, 0),
     }
-    MESSAGE_WIRE_TYPE = 13
 
     def __init__(
         self,
@@ -25,8 +25,7 @@ class LoadDevice(p.MessageType):
         language: str = None,
         label: str = None,
         skip_checksum: bool = None,
-        u2f_counter: int = None,
-        **kwargs
+        u2f_counter: int = None
     ) -> None:
         self.mnemonic = mnemonic
         self.node = node
@@ -36,4 +35,3 @@ class LoadDevice(p.MessageType):
         self.label = label
         self.skip_checksum = skip_checksum
         self.u2f_counter = u2f_counter
-        super().__init__(**kwargs)

--- a/src/trezor/messages/MessageSignature.py
+++ b/src/trezor/messages/MessageSignature.py
@@ -3,18 +3,16 @@ import protobuf as p
 
 
 class MessageSignature(p.MessageType):
+    MESSAGE_WIRE_TYPE = 40
     FIELDS = {
         1: ('address', p.UnicodeType, 0),
         2: ('signature', p.BytesType, 0),
     }
-    MESSAGE_WIRE_TYPE = 40
 
     def __init__(
         self,
         address: str = None,
-        signature: bytes = None,
-        **kwargs
+        signature: bytes = None
     ) -> None:
         self.address = address
         self.signature = signature
-        super().__init__(**kwargs)

--- a/src/trezor/messages/MultisigRedeemScriptType.py
+++ b/src/trezor/messages/MultisigRedeemScriptType.py
@@ -19,10 +19,8 @@ class MultisigRedeemScriptType(p.MessageType):
         self,
         pubkeys: List[HDNodePathType] = None,
         signatures: List[bytes] = None,
-        m: int = None,
-        **kwargs
+        m: int = None
     ) -> None:
         self.pubkeys = pubkeys if pubkeys is not None else []
         self.signatures = signatures if signatures is not None else []
         self.m = m
-        super().__init__(**kwargs)

--- a/src/trezor/messages/NEMAddress.py
+++ b/src/trezor/messages/NEMAddress.py
@@ -3,15 +3,13 @@ import protobuf as p
 
 
 class NEMAddress(p.MessageType):
+    MESSAGE_WIRE_TYPE = 68
     FIELDS = {
         1: ('address', p.UnicodeType, 0),  # required
     }
-    MESSAGE_WIRE_TYPE = 68
 
     def __init__(
         self,
-        address: str = None,
-        **kwargs
+        address: str = None
     ) -> None:
         self.address = address
-        super().__init__(**kwargs)

--- a/src/trezor/messages/NEMAggregateModification.py
+++ b/src/trezor/messages/NEMAggregateModification.py
@@ -17,9 +17,7 @@ class NEMAggregateModification(p.MessageType):
     def __init__(
         self,
         modifications: List[NEMCosignatoryModification] = None,
-        relative_change: int = None,
-        **kwargs
+        relative_change: int = None
     ) -> None:
         self.modifications = modifications if modifications is not None else []
         self.relative_change = relative_change
-        super().__init__(**kwargs)

--- a/src/trezor/messages/NEMCosignatoryModification.py
+++ b/src/trezor/messages/NEMCosignatoryModification.py
@@ -11,9 +11,7 @@ class NEMCosignatoryModification(p.MessageType):
     def __init__(
         self,
         type: int = None,
-        public_key: bytes = None,
-        **kwargs
+        public_key: bytes = None
     ) -> None:
         self.type = type
         self.public_key = public_key
-        super().__init__(**kwargs)

--- a/src/trezor/messages/NEMDecryptMessage.py
+++ b/src/trezor/messages/NEMDecryptMessage.py
@@ -8,24 +8,22 @@ if __debug__:
 
 
 class NEMDecryptMessage(p.MessageType):
+    MESSAGE_WIRE_TYPE = 75
     FIELDS = {
         1: ('address_n', p.UVarintType, p.FLAG_REPEATED),
         2: ('network', p.UVarintType, 0),
         3: ('public_key', p.BytesType, 0),
         4: ('payload', p.BytesType, 0),
     }
-    MESSAGE_WIRE_TYPE = 75
 
     def __init__(
         self,
         address_n: List[int] = None,
         network: int = None,
         public_key: bytes = None,
-        payload: bytes = None,
-        **kwargs
+        payload: bytes = None
     ) -> None:
         self.address_n = address_n if address_n is not None else []
         self.network = network
         self.public_key = public_key
         self.payload = payload
-        super().__init__(**kwargs)

--- a/src/trezor/messages/NEMDecryptedMessage.py
+++ b/src/trezor/messages/NEMDecryptedMessage.py
@@ -3,15 +3,13 @@ import protobuf as p
 
 
 class NEMDecryptedMessage(p.MessageType):
+    MESSAGE_WIRE_TYPE = 76
     FIELDS = {
         1: ('payload', p.BytesType, 0),
     }
-    MESSAGE_WIRE_TYPE = 76
 
     def __init__(
         self,
-        payload: bytes = None,
-        **kwargs
+        payload: bytes = None
     ) -> None:
         self.payload = payload
-        super().__init__(**kwargs)

--- a/src/trezor/messages/NEMGetAddress.py
+++ b/src/trezor/messages/NEMGetAddress.py
@@ -8,21 +8,19 @@ if __debug__:
 
 
 class NEMGetAddress(p.MessageType):
+    MESSAGE_WIRE_TYPE = 67
     FIELDS = {
         1: ('address_n', p.UVarintType, p.FLAG_REPEATED),
         2: ('network', p.UVarintType, 0),
         3: ('show_display', p.BoolType, 0),
     }
-    MESSAGE_WIRE_TYPE = 67
 
     def __init__(
         self,
         address_n: List[int] = None,
         network: int = None,
-        show_display: bool = None,
-        **kwargs
+        show_display: bool = None
     ) -> None:
         self.address_n = address_n if address_n is not None else []
         self.network = network
         self.show_display = show_display
-        super().__init__(**kwargs)

--- a/src/trezor/messages/NEMImportanceTransfer.py
+++ b/src/trezor/messages/NEMImportanceTransfer.py
@@ -11,9 +11,7 @@ class NEMImportanceTransfer(p.MessageType):
     def __init__(
         self,
         mode: int = None,
-        public_key: bytes = None,
-        **kwargs
+        public_key: bytes = None
     ) -> None:
         self.mode = mode
         self.public_key = public_key
-        super().__init__(**kwargs)

--- a/src/trezor/messages/NEMMosaic.py
+++ b/src/trezor/messages/NEMMosaic.py
@@ -13,10 +13,8 @@ class NEMMosaic(p.MessageType):
         self,
         namespace: str = None,
         mosaic: str = None,
-        quantity: int = None,
-        **kwargs
+        quantity: int = None
     ) -> None:
         self.namespace = namespace
         self.mosaic = mosaic
         self.quantity = quantity
-        super().__init__(**kwargs)

--- a/src/trezor/messages/NEMMosaicCreation.py
+++ b/src/trezor/messages/NEMMosaicCreation.py
@@ -14,10 +14,8 @@ class NEMMosaicCreation(p.MessageType):
         self,
         definition: NEMMosaicDefinition = None,
         sink: str = None,
-        fee: int = None,
-        **kwargs
+        fee: int = None
     ) -> None:
         self.definition = definition
         self.sink = sink
         self.fee = fee
-        super().__init__(**kwargs)

--- a/src/trezor/messages/NEMMosaicDefinition.py
+++ b/src/trezor/messages/NEMMosaicDefinition.py
@@ -42,8 +42,7 @@ class NEMMosaicDefinition(p.MessageType):
         mutable_supply: bool = None,
         transferable: bool = None,
         description: str = None,
-        networks: List[int] = None,
-        **kwargs
+        networks: List[int] = None
     ) -> None:
         self.name = name
         self.ticker = ticker
@@ -60,4 +59,3 @@ class NEMMosaicDefinition(p.MessageType):
         self.transferable = transferable
         self.description = description
         self.networks = networks if networks is not None else []
-        super().__init__(**kwargs)

--- a/src/trezor/messages/NEMMosaicSupplyChange.py
+++ b/src/trezor/messages/NEMMosaicSupplyChange.py
@@ -15,11 +15,9 @@ class NEMMosaicSupplyChange(p.MessageType):
         namespace: str = None,
         mosaic: str = None,
         type: int = None,
-        delta: int = None,
-        **kwargs
+        delta: int = None
     ) -> None:
         self.namespace = namespace
         self.mosaic = mosaic
         self.type = type
         self.delta = delta
-        super().__init__(**kwargs)

--- a/src/trezor/messages/NEMProvisionNamespace.py
+++ b/src/trezor/messages/NEMProvisionNamespace.py
@@ -15,11 +15,9 @@ class NEMProvisionNamespace(p.MessageType):
         namespace: str = None,
         parent: str = None,
         sink: str = None,
-        fee: int = None,
-        **kwargs
+        fee: int = None
     ) -> None:
         self.namespace = namespace
         self.parent = parent
         self.sink = sink
         self.fee = fee
-        super().__init__(**kwargs)

--- a/src/trezor/messages/NEMSignTx.py
+++ b/src/trezor/messages/NEMSignTx.py
@@ -10,6 +10,7 @@ from .NEMTransfer import NEMTransfer
 
 
 class NEMSignTx(p.MessageType):
+    MESSAGE_WIRE_TYPE = 69
     FIELDS = {
         1: ('transaction', NEMTransactionCommon, 0),
         2: ('multisig', NEMTransactionCommon, 0),
@@ -21,7 +22,6 @@ class NEMSignTx(p.MessageType):
         8: ('aggregate_modification', NEMAggregateModification, 0),
         9: ('importance_transfer', NEMImportanceTransfer, 0),
     }
-    MESSAGE_WIRE_TYPE = 69
 
     def __init__(
         self,
@@ -33,8 +33,7 @@ class NEMSignTx(p.MessageType):
         mosaic_creation: NEMMosaicCreation = None,
         supply_change: NEMMosaicSupplyChange = None,
         aggregate_modification: NEMAggregateModification = None,
-        importance_transfer: NEMImportanceTransfer = None,
-        **kwargs
+        importance_transfer: NEMImportanceTransfer = None
     ) -> None:
         self.transaction = transaction
         self.multisig = multisig
@@ -45,4 +44,3 @@ class NEMSignTx(p.MessageType):
         self.supply_change = supply_change
         self.aggregate_modification = aggregate_modification
         self.importance_transfer = importance_transfer
-        super().__init__(**kwargs)

--- a/src/trezor/messages/NEMSignedTx.py
+++ b/src/trezor/messages/NEMSignedTx.py
@@ -3,18 +3,16 @@ import protobuf as p
 
 
 class NEMSignedTx(p.MessageType):
+    MESSAGE_WIRE_TYPE = 70
     FIELDS = {
         1: ('data', p.BytesType, 0),
         2: ('signature', p.BytesType, 0),
     }
-    MESSAGE_WIRE_TYPE = 70
 
     def __init__(
         self,
         data: bytes = None,
-        signature: bytes = None,
-        **kwargs
+        signature: bytes = None
     ) -> None:
         self.data = data
         self.signature = signature
-        super().__init__(**kwargs)

--- a/src/trezor/messages/NEMTransactionCommon.py
+++ b/src/trezor/messages/NEMTransactionCommon.py
@@ -24,8 +24,7 @@ class NEMTransactionCommon(p.MessageType):
         timestamp: int = None,
         fee: int = None,
         deadline: int = None,
-        signer: bytes = None,
-        **kwargs
+        signer: bytes = None
     ) -> None:
         self.address_n = address_n if address_n is not None else []
         self.network = network
@@ -33,4 +32,3 @@ class NEMTransactionCommon(p.MessageType):
         self.fee = fee
         self.deadline = deadline
         self.signer = signer
-        super().__init__(**kwargs)

--- a/src/trezor/messages/NEMTransfer.py
+++ b/src/trezor/messages/NEMTransfer.py
@@ -23,12 +23,10 @@ class NEMTransfer(p.MessageType):
         amount: int = None,
         payload: bytes = None,
         public_key: bytes = None,
-        mosaics: List[NEMMosaic] = None,
-        **kwargs
+        mosaics: List[NEMMosaic] = None
     ) -> None:
         self.recipient = recipient
         self.amount = amount
         self.payload = payload
         self.public_key = public_key
         self.mosaics = mosaics if mosaics is not None else []
-        super().__init__(**kwargs)

--- a/src/trezor/messages/PassphraseAck.py
+++ b/src/trezor/messages/PassphraseAck.py
@@ -3,18 +3,16 @@ import protobuf as p
 
 
 class PassphraseAck(p.MessageType):
+    MESSAGE_WIRE_TYPE = 42
     FIELDS = {
         1: ('passphrase', p.UnicodeType, 0),
         2: ('state', p.BytesType, 0),
     }
-    MESSAGE_WIRE_TYPE = 42
 
     def __init__(
         self,
         passphrase: str = None,
-        state: bytes = None,
-        **kwargs
+        state: bytes = None
     ) -> None:
         self.passphrase = passphrase
         self.state = state
-        super().__init__(**kwargs)

--- a/src/trezor/messages/PassphraseRequest.py
+++ b/src/trezor/messages/PassphraseRequest.py
@@ -3,15 +3,13 @@ import protobuf as p
 
 
 class PassphraseRequest(p.MessageType):
+    MESSAGE_WIRE_TYPE = 41
     FIELDS = {
         1: ('on_device', p.BoolType, 0),
     }
-    MESSAGE_WIRE_TYPE = 41
 
     def __init__(
         self,
-        on_device: bool = None,
-        **kwargs
+        on_device: bool = None
     ) -> None:
         self.on_device = on_device
-        super().__init__(**kwargs)

--- a/src/trezor/messages/PassphraseStateAck.py
+++ b/src/trezor/messages/PassphraseStateAck.py
@@ -4,9 +4,3 @@ import protobuf as p
 
 class PassphraseStateAck(p.MessageType):
     MESSAGE_WIRE_TYPE = 78
-
-    def __init__(
-        self,
-        **kwargs
-    ) -> None:
-        super().__init__(**kwargs)

--- a/src/trezor/messages/PassphraseStateRequest.py
+++ b/src/trezor/messages/PassphraseStateRequest.py
@@ -3,15 +3,13 @@ import protobuf as p
 
 
 class PassphraseStateRequest(p.MessageType):
+    MESSAGE_WIRE_TYPE = 77
     FIELDS = {
         1: ('state', p.BytesType, 0),
     }
-    MESSAGE_WIRE_TYPE = 77
 
     def __init__(
         self,
-        state: bytes = None,
-        **kwargs
+        state: bytes = None
     ) -> None:
         self.state = state
-        super().__init__(**kwargs)

--- a/src/trezor/messages/PinMatrixAck.py
+++ b/src/trezor/messages/PinMatrixAck.py
@@ -3,15 +3,13 @@ import protobuf as p
 
 
 class PinMatrixAck(p.MessageType):
+    MESSAGE_WIRE_TYPE = 19
     FIELDS = {
         1: ('pin', p.UnicodeType, 0),  # required
     }
-    MESSAGE_WIRE_TYPE = 19
 
     def __init__(
         self,
-        pin: str = None,
-        **kwargs
+        pin: str = None
     ) -> None:
         self.pin = pin
-        super().__init__(**kwargs)

--- a/src/trezor/messages/PinMatrixRequest.py
+++ b/src/trezor/messages/PinMatrixRequest.py
@@ -3,15 +3,13 @@ import protobuf as p
 
 
 class PinMatrixRequest(p.MessageType):
+    MESSAGE_WIRE_TYPE = 18
     FIELDS = {
         1: ('type', p.UVarintType, 0),
     }
-    MESSAGE_WIRE_TYPE = 18
 
     def __init__(
         self,
-        type: int = None,
-        **kwargs
+        type: int = None
     ) -> None:
         self.type = type
-        super().__init__(**kwargs)

--- a/src/trezor/messages/Ping.py
+++ b/src/trezor/messages/Ping.py
@@ -3,24 +3,22 @@ import protobuf as p
 
 
 class Ping(p.MessageType):
+    MESSAGE_WIRE_TYPE = 1
     FIELDS = {
         1: ('message', p.UnicodeType, 0),
         2: ('button_protection', p.BoolType, 0),
         3: ('pin_protection', p.BoolType, 0),
         4: ('passphrase_protection', p.BoolType, 0),
     }
-    MESSAGE_WIRE_TYPE = 1
 
     def __init__(
         self,
         message: str = None,
         button_protection: bool = None,
         pin_protection: bool = None,
-        passphrase_protection: bool = None,
-        **kwargs
+        passphrase_protection: bool = None
     ) -> None:
         self.message = message
         self.button_protection = button_protection
         self.pin_protection = pin_protection
         self.passphrase_protection = passphrase_protection
-        super().__init__(**kwargs)

--- a/src/trezor/messages/PublicKey.py
+++ b/src/trezor/messages/PublicKey.py
@@ -4,18 +4,16 @@ from .HDNodeType import HDNodeType
 
 
 class PublicKey(p.MessageType):
+    MESSAGE_WIRE_TYPE = 12
     FIELDS = {
         1: ('node', HDNodeType, 0),  # required
         2: ('xpub', p.UnicodeType, 0),
     }
-    MESSAGE_WIRE_TYPE = 12
 
     def __init__(
         self,
         node: HDNodeType = None,
-        xpub: str = None,
-        **kwargs
+        xpub: str = None
     ) -> None:
         self.node = node
         self.xpub = xpub
-        super().__init__(**kwargs)

--- a/src/trezor/messages/RecoveryDevice.py
+++ b/src/trezor/messages/RecoveryDevice.py
@@ -3,6 +3,7 @@ import protobuf as p
 
 
 class RecoveryDevice(p.MessageType):
+    MESSAGE_WIRE_TYPE = 45
     FIELDS = {
         1: ('word_count', p.UVarintType, 0),
         2: ('passphrase_protection', p.BoolType, 0),
@@ -14,7 +15,6 @@ class RecoveryDevice(p.MessageType):
         9: ('u2f_counter', p.UVarintType, 0),
         10: ('dry_run', p.BoolType, 0),
     }
-    MESSAGE_WIRE_TYPE = 45
 
     def __init__(
         self,
@@ -26,8 +26,7 @@ class RecoveryDevice(p.MessageType):
         enforce_wordlist: bool = None,
         type: int = None,
         u2f_counter: int = None,
-        dry_run: bool = None,
-        **kwargs
+        dry_run: bool = None
     ) -> None:
         self.word_count = word_count
         self.passphrase_protection = passphrase_protection
@@ -38,4 +37,3 @@ class RecoveryDevice(p.MessageType):
         self.type = type
         self.u2f_counter = u2f_counter
         self.dry_run = dry_run
-        super().__init__(**kwargs)

--- a/src/trezor/messages/ResetDevice.py
+++ b/src/trezor/messages/ResetDevice.py
@@ -3,6 +3,7 @@ import protobuf as p
 
 
 class ResetDevice(p.MessageType):
+    MESSAGE_WIRE_TYPE = 14
     FIELDS = {
         1: ('display_random', p.BoolType, 0),
         2: ('strength', p.UVarintType, 0),  # default=256
@@ -13,7 +14,6 @@ class ResetDevice(p.MessageType):
         7: ('u2f_counter', p.UVarintType, 0),
         8: ('skip_backup', p.BoolType, 0),
     }
-    MESSAGE_WIRE_TYPE = 14
 
     def __init__(
         self,
@@ -24,8 +24,7 @@ class ResetDevice(p.MessageType):
         language: str = None,
         label: str = None,
         u2f_counter: int = None,
-        skip_backup: bool = None,
-        **kwargs
+        skip_backup: bool = None
     ) -> None:
         self.display_random = display_random
         self.strength = strength
@@ -35,4 +34,3 @@ class ResetDevice(p.MessageType):
         self.label = label
         self.u2f_counter = u2f_counter
         self.skip_backup = skip_backup
-        super().__init__(**kwargs)

--- a/src/trezor/messages/SelfTest.py
+++ b/src/trezor/messages/SelfTest.py
@@ -3,15 +3,13 @@ import protobuf as p
 
 
 class SelfTest(p.MessageType):
+    MESSAGE_WIRE_TYPE = 32
     FIELDS = {
         1: ('payload', p.BytesType, 0),
     }
-    MESSAGE_WIRE_TYPE = 32
 
     def __init__(
         self,
-        payload: bytes = None,
-        **kwargs
+        payload: bytes = None
     ) -> None:
         self.payload = payload
-        super().__init__(**kwargs)

--- a/src/trezor/messages/SetU2FCounter.py
+++ b/src/trezor/messages/SetU2FCounter.py
@@ -3,15 +3,13 @@ import protobuf as p
 
 
 class SetU2FCounter(p.MessageType):
+    MESSAGE_WIRE_TYPE = 63
     FIELDS = {
         1: ('u2f_counter', p.UVarintType, 0),
     }
-    MESSAGE_WIRE_TYPE = 63
 
     def __init__(
         self,
-        u2f_counter: int = None,
-        **kwargs
+        u2f_counter: int = None
     ) -> None:
         self.u2f_counter = u2f_counter
-        super().__init__(**kwargs)

--- a/src/trezor/messages/SignIdentity.py
+++ b/src/trezor/messages/SignIdentity.py
@@ -4,24 +4,22 @@ from .IdentityType import IdentityType
 
 
 class SignIdentity(p.MessageType):
+    MESSAGE_WIRE_TYPE = 53
     FIELDS = {
         1: ('identity', IdentityType, 0),
         2: ('challenge_hidden', p.BytesType, 0),
         3: ('challenge_visual', p.UnicodeType, 0),
         4: ('ecdsa_curve_name', p.UnicodeType, 0),
     }
-    MESSAGE_WIRE_TYPE = 53
 
     def __init__(
         self,
         identity: IdentityType = None,
         challenge_hidden: bytes = None,
         challenge_visual: str = None,
-        ecdsa_curve_name: str = None,
-        **kwargs
+        ecdsa_curve_name: str = None
     ) -> None:
         self.identity = identity
         self.challenge_hidden = challenge_hidden
         self.challenge_visual = challenge_visual
         self.ecdsa_curve_name = ecdsa_curve_name
-        super().__init__(**kwargs)

--- a/src/trezor/messages/SignMessage.py
+++ b/src/trezor/messages/SignMessage.py
@@ -8,24 +8,22 @@ if __debug__:
 
 
 class SignMessage(p.MessageType):
+    MESSAGE_WIRE_TYPE = 38
     FIELDS = {
         1: ('address_n', p.UVarintType, p.FLAG_REPEATED),
         2: ('message', p.BytesType, 0),  # required
         3: ('coin_name', p.UnicodeType, 0),  # default='Bitcoin'
         4: ('script_type', p.UVarintType, 0),  # default=0
     }
-    MESSAGE_WIRE_TYPE = 38
 
     def __init__(
         self,
         address_n: List[int] = None,
         message: bytes = None,
         coin_name: str = None,
-        script_type: int = None,
-        **kwargs
+        script_type: int = None
     ) -> None:
         self.address_n = address_n if address_n is not None else []
         self.message = message
         self.coin_name = coin_name
         self.script_type = script_type
-        super().__init__(**kwargs)

--- a/src/trezor/messages/SignTx.py
+++ b/src/trezor/messages/SignTx.py
@@ -3,6 +3,7 @@ import protobuf as p
 
 
 class SignTx(p.MessageType):
+    MESSAGE_WIRE_TYPE = 15
     FIELDS = {
         1: ('outputs_count', p.UVarintType, 0),  # required
         2: ('inputs_count', p.UVarintType, 0),  # required
@@ -11,7 +12,6 @@ class SignTx(p.MessageType):
         5: ('lock_time', p.UVarintType, 0),  # default=0
         6: ('decred_expiry', p.UVarintType, 0),
     }
-    MESSAGE_WIRE_TYPE = 15
 
     def __init__(
         self,
@@ -20,8 +20,7 @@ class SignTx(p.MessageType):
         coin_name: str = None,
         version: int = None,
         lock_time: int = None,
-        decred_expiry: int = None,
-        **kwargs
+        decred_expiry: int = None
     ) -> None:
         self.outputs_count = outputs_count
         self.inputs_count = inputs_count
@@ -29,4 +28,3 @@ class SignTx(p.MessageType):
         self.version = version
         self.lock_time = lock_time
         self.decred_expiry = decred_expiry
-        super().__init__(**kwargs)

--- a/src/trezor/messages/SignedIdentity.py
+++ b/src/trezor/messages/SignedIdentity.py
@@ -3,21 +3,19 @@ import protobuf as p
 
 
 class SignedIdentity(p.MessageType):
+    MESSAGE_WIRE_TYPE = 54
     FIELDS = {
         1: ('address', p.UnicodeType, 0),
         2: ('public_key', p.BytesType, 0),
         3: ('signature', p.BytesType, 0),
     }
-    MESSAGE_WIRE_TYPE = 54
 
     def __init__(
         self,
         address: str = None,
         public_key: bytes = None,
-        signature: bytes = None,
-        **kwargs
+        signature: bytes = None
     ) -> None:
         self.address = address
         self.public_key = public_key
         self.signature = signature
-        super().__init__(**kwargs)

--- a/src/trezor/messages/SimpleSignTx.py
+++ b/src/trezor/messages/SimpleSignTx.py
@@ -11,6 +11,7 @@ from .TxOutputType import TxOutputType
 
 
 class SimpleSignTx(p.MessageType):
+    MESSAGE_WIRE_TYPE = 16
     FIELDS = {
         1: ('inputs', TxInputType, p.FLAG_REPEATED),
         2: ('outputs', TxOutputType, p.FLAG_REPEATED),
@@ -19,7 +20,6 @@ class SimpleSignTx(p.MessageType):
         5: ('version', p.UVarintType, 0),  # default=1
         6: ('lock_time', p.UVarintType, 0),  # default=0
     }
-    MESSAGE_WIRE_TYPE = 16
 
     def __init__(
         self,
@@ -28,8 +28,7 @@ class SimpleSignTx(p.MessageType):
         transactions: List[TransactionType] = None,
         coin_name: str = None,
         version: int = None,
-        lock_time: int = None,
-        **kwargs
+        lock_time: int = None
     ) -> None:
         self.inputs = inputs if inputs is not None else []
         self.outputs = outputs if outputs is not None else []
@@ -37,4 +36,3 @@ class SimpleSignTx(p.MessageType):
         self.coin_name = coin_name
         self.version = version
         self.lock_time = lock_time
-        super().__init__(**kwargs)

--- a/src/trezor/messages/Success.py
+++ b/src/trezor/messages/Success.py
@@ -3,15 +3,13 @@ import protobuf as p
 
 
 class Success(p.MessageType):
+    MESSAGE_WIRE_TYPE = 2
     FIELDS = {
         1: ('message', p.UnicodeType, 0),
     }
-    MESSAGE_WIRE_TYPE = 2
 
     def __init__(
         self,
-        message: str = None,
-        **kwargs
+        message: str = None
     ) -> None:
         self.message = message
-        super().__init__(**kwargs)

--- a/src/trezor/messages/TransactionType.py
+++ b/src/trezor/messages/TransactionType.py
@@ -35,8 +35,7 @@ class TransactionType(p.MessageType):
         outputs_cnt: int = None,
         extra_data: bytes = None,
         extra_data_len: int = None,
-        decred_expiry: int = None,
-        **kwargs
+        decred_expiry: int = None
     ) -> None:
         self.version = version
         self.inputs = inputs if inputs is not None else []
@@ -48,4 +47,3 @@ class TransactionType(p.MessageType):
         self.extra_data = extra_data
         self.extra_data_len = extra_data_len
         self.decred_expiry = decred_expiry
-        super().__init__(**kwargs)

--- a/src/trezor/messages/TxAck.py
+++ b/src/trezor/messages/TxAck.py
@@ -4,15 +4,13 @@ from .TransactionType import TransactionType
 
 
 class TxAck(p.MessageType):
+    MESSAGE_WIRE_TYPE = 22
     FIELDS = {
         1: ('tx', TransactionType, 0),
     }
-    MESSAGE_WIRE_TYPE = 22
 
     def __init__(
         self,
-        tx: TransactionType = None,
-        **kwargs
+        tx: TransactionType = None
     ) -> None:
         self.tx = tx
-        super().__init__(**kwargs)

--- a/src/trezor/messages/TxInputType.py
+++ b/src/trezor/messages/TxInputType.py
@@ -33,8 +33,7 @@ class TxInputType(p.MessageType):
         multisig: MultisigRedeemScriptType = None,
         amount: int = None,
         decred_tree: int = None,
-        decred_script_version: int = None,
-        **kwargs
+        decred_script_version: int = None
     ) -> None:
         self.address_n = address_n if address_n is not None else []
         self.prev_hash = prev_hash
@@ -46,4 +45,3 @@ class TxInputType(p.MessageType):
         self.amount = amount
         self.decred_tree = decred_tree
         self.decred_script_version = decred_script_version
-        super().__init__(**kwargs)

--- a/src/trezor/messages/TxOutputBinType.py
+++ b/src/trezor/messages/TxOutputBinType.py
@@ -13,10 +13,8 @@ class TxOutputBinType(p.MessageType):
         self,
         amount: int = None,
         script_pubkey: bytes = None,
-        decred_script_version: int = None,
-        **kwargs
+        decred_script_version: int = None
     ) -> None:
         self.amount = amount
         self.script_pubkey = script_pubkey
         self.decred_script_version = decred_script_version
-        super().__init__(**kwargs)

--- a/src/trezor/messages/TxOutputType.py
+++ b/src/trezor/messages/TxOutputType.py
@@ -27,8 +27,7 @@ class TxOutputType(p.MessageType):
         script_type: int = None,
         multisig: MultisigRedeemScriptType = None,
         op_return_data: bytes = None,
-        decred_script_version: int = None,
-        **kwargs
+        decred_script_version: int = None
     ) -> None:
         self.address = address
         self.address_n = address_n if address_n is not None else []
@@ -37,4 +36,3 @@ class TxOutputType(p.MessageType):
         self.multisig = multisig
         self.op_return_data = op_return_data
         self.decred_script_version = decred_script_version
-        super().__init__(**kwargs)

--- a/src/trezor/messages/TxRequest.py
+++ b/src/trezor/messages/TxRequest.py
@@ -5,21 +5,19 @@ from .TxRequestSerializedType import TxRequestSerializedType
 
 
 class TxRequest(p.MessageType):
+    MESSAGE_WIRE_TYPE = 21
     FIELDS = {
         1: ('request_type', p.UVarintType, 0),
         2: ('details', TxRequestDetailsType, 0),
         3: ('serialized', TxRequestSerializedType, 0),
     }
-    MESSAGE_WIRE_TYPE = 21
 
     def __init__(
         self,
         request_type: int = None,
         details: TxRequestDetailsType = None,
-        serialized: TxRequestSerializedType = None,
-        **kwargs
+        serialized: TxRequestSerializedType = None
     ) -> None:
         self.request_type = request_type
         self.details = details
         self.serialized = serialized
-        super().__init__(**kwargs)

--- a/src/trezor/messages/TxRequestDetailsType.py
+++ b/src/trezor/messages/TxRequestDetailsType.py
@@ -15,11 +15,9 @@ class TxRequestDetailsType(p.MessageType):
         request_index: int = None,
         tx_hash: bytes = None,
         extra_data_len: int = None,
-        extra_data_offset: int = None,
-        **kwargs
+        extra_data_offset: int = None
     ) -> None:
         self.request_index = request_index
         self.tx_hash = tx_hash
         self.extra_data_len = extra_data_len
         self.extra_data_offset = extra_data_offset
-        super().__init__(**kwargs)

--- a/src/trezor/messages/TxRequestSerializedType.py
+++ b/src/trezor/messages/TxRequestSerializedType.py
@@ -13,10 +13,8 @@ class TxRequestSerializedType(p.MessageType):
         self,
         signature_index: int = None,
         signature: bytes = None,
-        serialized_tx: bytes = None,
-        **kwargs
+        serialized_tx: bytes = None
     ) -> None:
         self.signature_index = signature_index
         self.signature = signature
         self.serialized_tx = serialized_tx
-        super().__init__(**kwargs)

--- a/src/trezor/messages/TxSize.py
+++ b/src/trezor/messages/TxSize.py
@@ -3,15 +3,13 @@ import protobuf as p
 
 
 class TxSize(p.MessageType):
+    MESSAGE_WIRE_TYPE = 44
     FIELDS = {
         1: ('tx_size', p.UVarintType, 0),
     }
-    MESSAGE_WIRE_TYPE = 44
 
     def __init__(
         self,
-        tx_size: int = None,
-        **kwargs
+        tx_size: int = None
     ) -> None:
         self.tx_size = tx_size
-        super().__init__(**kwargs)

--- a/src/trezor/messages/VerifyMessage.py
+++ b/src/trezor/messages/VerifyMessage.py
@@ -3,24 +3,22 @@ import protobuf as p
 
 
 class VerifyMessage(p.MessageType):
+    MESSAGE_WIRE_TYPE = 39
     FIELDS = {
         1: ('address', p.UnicodeType, 0),
         2: ('signature', p.BytesType, 0),
         3: ('message', p.BytesType, 0),
         4: ('coin_name', p.UnicodeType, 0),  # default='Bitcoin'
     }
-    MESSAGE_WIRE_TYPE = 39
 
     def __init__(
         self,
         address: str = None,
         signature: bytes = None,
         message: bytes = None,
-        coin_name: str = None,
-        **kwargs
+        coin_name: str = None
     ) -> None:
         self.address = address
         self.signature = signature
         self.message = message
         self.coin_name = coin_name
-        super().__init__(**kwargs)

--- a/src/trezor/messages/WipeDevice.py
+++ b/src/trezor/messages/WipeDevice.py
@@ -4,9 +4,3 @@ import protobuf as p
 
 class WipeDevice(p.MessageType):
     MESSAGE_WIRE_TYPE = 5
-
-    def __init__(
-        self,
-        **kwargs
-    ) -> None:
-        super().__init__(**kwargs)

--- a/src/trezor/messages/WordAck.py
+++ b/src/trezor/messages/WordAck.py
@@ -3,15 +3,13 @@ import protobuf as p
 
 
 class WordAck(p.MessageType):
+    MESSAGE_WIRE_TYPE = 47
     FIELDS = {
         1: ('word', p.UnicodeType, 0),  # required
     }
-    MESSAGE_WIRE_TYPE = 47
 
     def __init__(
         self,
-        word: str = None,
-        **kwargs
+        word: str = None
     ) -> None:
         self.word = word
-        super().__init__(**kwargs)

--- a/src/trezor/messages/WordRequest.py
+++ b/src/trezor/messages/WordRequest.py
@@ -3,15 +3,13 @@ import protobuf as p
 
 
 class WordRequest(p.MessageType):
+    MESSAGE_WIRE_TYPE = 46
     FIELDS = {
         1: ('type', p.UVarintType, 0),
     }
-    MESSAGE_WIRE_TYPE = 46
 
     def __init__(
         self,
-        type: int = None,
-        **kwargs
+        type: int = None
     ) -> None:
         self.type = type
-        super().__init__(**kwargs)

--- a/tools/pb2py
+++ b/tools/pb2py
@@ -76,16 +76,17 @@ def process_message_imports(descriptor):
 def create_init_method(fields):
     yield         "    def __init__("
     yield         "        self,"
-    for field in fields:
+    for field in fields[:-1]:
         yield     "        %s: %s = None," % (field.name, field.py_type)
-    yield         "        **kwargs"
+    # last field must not have a traling comma
+    yield         "        %s: %s = None" % (fields[-1].name, fields[-1].py_type)
     yield         "    ) -> None:"
+
     for field in fields:
         if field.repeated:
             yield "        self.{0} = {0} if {0} is not None else []".format(field.name)
         else:
             yield "        self.{0} = {0}".format(field.name)
-    yield         "        super().__init__(**kwargs)"
 
 
 def process_message(descriptor, protobuf_module, msg_id, is_upy):
@@ -113,6 +114,9 @@ def process_message(descriptor, protobuf_module, msg_id, is_upy):
     yield ""
     yield "class %s(p.MessageType):" % descriptor.name
 
+    if msg_id is not None:
+        yield "    MESSAGE_WIRE_TYPE = %d" % msg_id
+
     if fields:
         yield "    FIELDS = {"
         for field in fields:
@@ -135,12 +139,11 @@ def process_message(descriptor, protobuf_module, msg_id, is_upy):
             yield "        %d: ('%s', %s, %s),%s" % (field.number, field.name, field.proto_type, flags, comment)
 
         yield "    }"
+        yield ""
+        yield from create_init_method(fields)
 
-    if msg_id is not None:
-        yield "    MESSAGE_WIRE_TYPE = %d" % msg_id
-
-    yield ""
-    yield from create_init_method(fields)
+    if not fields and not msg_id:
+        yield "    pass"
 
 
 def process_enum(descriptor, is_upy):


### PR DESCRIPTION
This is a follow-up to #197. I'm opening this as a PR to the `pb2py-refactor` branch for review purposes only.

What this does:
- removes `**kwargs` arguments to protobuf classes
- adapts `CoinTypes` to handle that

Important things to note (in fa18652 commit message):

1. the `CoinTypes` subclass should have an explicit (and appropriately typed) list of properties, but it doesn't now.
2. there's several places where `messages.CoinType` is expected but that use properties which belong to `coins.CoinType` now. Type hints should be updated at some point. But right now that would mean importing `coins.py` in these places, and that might not be what we want.
  Given that typing is not enforced yet, this doesn't matter, and it will become obvious whenever we start enforcing it.