### PR TITLE
eth: unknown token transfer is recognized and displayed as unknown

### DIFF
--- a/src/apps/ethereum/layout.py
+++ b/src/apps/ethereum/layout.py
@@ -1,4 +1,5 @@
 from apps.common.confirm import *
+from apps.ethereum import tokens
 from trezor import ui
 from trezor.utils import chunks, format_amount
 from trezor.messages import ButtonRequestType
@@ -53,6 +54,8 @@ def split_address(address):
 
 def format_ethereum_amount(value: int, token, chain_id: int, tx_type=None):
     if token:
+        if token is tokens.UNKNOWN_TOKEN:
+            return 'Unknown token value'
         suffix = token[2]
         decimals = token[3]
     else:

--- a/src/apps/ethereum/tokens.py
+++ b/src/apps/ethereum/tokens.py
@@ -1,11 +1,11 @@
 def token_by_chain_address(chain_id, address):
-    if not address:
-        return None
     for token in tokens:
         if chain_id == token[0] and address == token[1]:
             return token
-    return None
+    return UNKNOWN_TOKEN
 
+
+UNKNOWN_TOKEN = True
 
 # rest of the file is generated using trezor-common/ethereum_tokens-gen.py
 # DO NOT EDIT MANUALLY!

--- a/src/apps/ethereum/tokens.py
+++ b/src/apps/ethereum/tokens.py
@@ -5,7 +5,7 @@ def token_by_chain_address(chain_id, address):
     return UNKNOWN_TOKEN
 
 
-UNKNOWN_TOKEN = True
+UNKNOWN_TOKEN = (None, None, None, None)
 
 # rest of the file is generated using trezor-common/ethereum_tokens-gen.py
 # DO NOT EDIT MANUALLY!

--- a/tests/test_apps.ethereum.tokens.py
+++ b/tests/test_apps.ethereum.tokens.py
@@ -22,7 +22,7 @@ class TestEthereumTokens(unittest.TestCase):
 
         # invalid adress, invalid chain
         token = tokens.token_by_chain_address(999, b'\x00\xFF')
-        self.assertEqual(token, None)
+        self.assertEqual(token, tokens.UNKNOWN_TOKEN)
 
 
 if __name__ == '__main__':

--- a/tests/test_apps.ethereum.tokens.py
+++ b/tests/test_apps.ethereum.tokens.py
@@ -22,7 +22,7 @@ class TestEthereumTokens(unittest.TestCase):
 
         # invalid adress, invalid chain
         token = tokens.token_by_chain_address(999, b'\x00\xFF')
-        self.assertEqual(token, tokens.UNKNOWN_TOKEN)
+        self.assertIs(token, tokens.UNKNOWN_TOKEN)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
When unknown token was transferred (meaning: the token address was not listed in the tokens list), we didn't treat it as a token transfer but as some arbitrary data. Since we know it is a token transfer it is beneficial to display the user such information and notify them that the token is unknown. In other words that the value is unknown, because we do not know the divisibility, nor the token suffix.

closes #198