### PR TITLE
Introduce trezor_obj_get_int and trezor_obj_get_uint

### DIFF
--- a/embed/extmod/modtrezorconfig/modtrezorconfig.c
+++ b/embed/extmod/modtrezorconfig/modtrezorconfig.c
@@ -23,6 +23,8 @@
 
 #if MICROPY_PY_TREZORCONFIG
 
+#include "embed/extmod/trezorobj.h"
+
 #include "norcow.h"
 #include "storage.h"
 
@@ -46,7 +48,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_0(mod_trezorconfig_init_obj, mod_trezorconfig_ini
 ///     Check the given PIN. Returns True on success, False on failure.
 ///     '''
 STATIC mp_obj_t mod_trezorconfig_check_pin(mp_obj_t pin, mp_obj_t waitcallback) {
-    uint32_t pin_i = mp_obj_get_int(pin);
+    uint32_t pin_i = trezor_obj_get_uint(pin);
     if (sectrue != storage_check_pin(pin_i, waitcallback)) {
         return mp_const_false;
     }
@@ -60,7 +62,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(mod_trezorconfig_check_pin_obj, mod_trezorconfi
 ///     success, False on failure.
 ///     '''
 STATIC mp_obj_t mod_trezorconfig_unlock(mp_obj_t pin, mp_obj_t waitcallback) {
-    uint32_t pin_i = mp_obj_get_int(pin);
+    uint32_t pin_i = trezor_obj_get_uint(pin);
     if (sectrue != storage_unlock(pin_i, waitcallback)) {
         return mp_const_false;
     }
@@ -85,8 +87,8 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_0(mod_trezorconfig_has_pin_obj, mod_trezorconfig_
 ///     Change PIN. Returns True on success, False on failure.
 ///     '''
 STATIC mp_obj_t mod_trezorconfig_change_pin(mp_obj_t pin, mp_obj_t newpin, mp_obj_t waitcallback) {
-    uint32_t pin_i = mp_obj_get_int(pin);
-    uint32_t newpin_i = mp_obj_get_int(newpin);
+    uint32_t pin_i = trezor_obj_get_uint(pin);
+    uint32_t newpin_i = trezor_obj_get_uint(newpin);
     if (sectrue != storage_change_pin(pin_i, newpin_i, waitcallback)) {
         return mp_const_false;
     }
@@ -99,8 +101,8 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_3(mod_trezorconfig_change_pin_obj, mod_trezorconf
 ///     Gets a value of given key for given app (or empty bytes if not set).
 ///     '''
 STATIC mp_obj_t mod_trezorconfig_get(size_t n_args, const mp_obj_t *args) {
-    uint8_t app = mp_obj_get_int(args[0]) & 0x7F;
-    uint8_t key = mp_obj_get_int(args[1]);
+    uint8_t app = trezor_obj_get_uint8(args[0]) & 0x7F;
+    uint8_t key = trezor_obj_get_uint8(args[1]);
     if (n_args > 2 && args[2] == mp_const_true) {
         app |= 0x80;
     }
@@ -119,8 +121,8 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(mod_trezorconfig_get_obj, 2, 3, mod_t
 ///     Sets a value of given key for given app.
 ///     '''
 STATIC mp_obj_t mod_trezorconfig_set(size_t n_args, const mp_obj_t *args) {
-    uint8_t app = mp_obj_get_int(args[0]) & 0x7F;
-    uint8_t key = mp_obj_get_int(args[1]);
+    uint8_t app = trezor_obj_get_uint8(args[0]) & 0x7F;
+    uint8_t key = trezor_obj_get_uint8(args[1]);
     if (n_args > 3 && args[3] == mp_const_true) {
         app |= 0x80;
     }

--- a/embed/extmod/modtrezorcrypto/modtrezorcrypto-blake2b.h
+++ b/embed/extmod/modtrezorcrypto/modtrezorcrypto-blake2b.h
@@ -19,6 +19,8 @@
 
 #include "py/objstr.h"
 
+#include "embed/extmod/trezorobj.h"
+
 #include "blake2b.h"
 #include "memzero.h"
 
@@ -44,12 +46,12 @@ STATIC mp_obj_t mod_trezorcrypto_Blake2b_make_new(const mp_obj_type_t *type, siz
     int res = 0;
     // constructor called with key argument set
     if (n_args == 3) {
-        size_t outlen = mp_obj_get_int(args[1]);
+        size_t outlen = trezor_obj_get_uint(args[1]);
         mp_buffer_info_t key;
         mp_get_buffer_raise(args[2], &key, MP_BUFFER_READ);
         res = blake2b_InitKey(&(o->ctx), outlen, key.buf, key.len);
     } else if (n_args == 2) {
-        size_t outlen = mp_obj_get_int(args[1]);
+        size_t outlen = trezor_obj_get_uint(args[1]);
         res = blake2b_Init(&(o->ctx), outlen);
     } else {
         res = blake2b_Init(&(o->ctx), BLAKE2B_DIGEST_LENGTH);

--- a/embed/extmod/modtrezorcrypto/modtrezorcrypto-blake2s.h
+++ b/embed/extmod/modtrezorcrypto/modtrezorcrypto-blake2s.h
@@ -19,6 +19,8 @@
 
 #include "py/objstr.h"
 
+#include "embed/extmod/trezorobj.h"
+
 #include "blake2s.h"
 #include "memzero.h"
 
@@ -44,12 +46,12 @@ STATIC mp_obj_t mod_trezorcrypto_Blake2s_make_new(const mp_obj_type_t *type, siz
     int res = 0;
     // constructor called with key argument set
     if (n_args == 3) {
-        size_t outlen = mp_obj_get_int(args[1]);
+        size_t outlen = trezor_obj_get_uint(args[1]);
         mp_buffer_info_t key;
         mp_get_buffer_raise(args[2], &key, MP_BUFFER_READ);
         res = blake2s_InitKey(&(o->ctx), outlen, key.buf, key.len);
     } else if (n_args == 2) {
-        size_t outlen = mp_obj_get_int(args[1]);
+        size_t outlen = trezor_obj_get_uint(args[1]);
         res = blake2s_Init(&(o->ctx), outlen);
     } else {
         res = blake2s_Init(&(o->ctx), BLAKE2S_DIGEST_LENGTH);

--- a/embed/extmod/modtrezorcrypto/modtrezorcrypto-crc.h
+++ b/embed/extmod/modtrezorcrypto/modtrezorcrypto-crc.h
@@ -18,12 +18,15 @@
  */
 
 #include "py/objstr.h"
+
+#include "embed/extmod/trezorobj.h"
+
 #include "crc.h"
 
 mp_obj_t mod_trezorcrypto_crc_crc32(size_t n_args, const mp_obj_t *args) {
     mp_buffer_info_t bufinfo;
     mp_get_buffer_raise(args[0], &bufinfo, MP_BUFFER_READ);
-    uint32_t crc = (n_args > 1) ? mp_obj_get_int_truncated(args[1]) : 0;
+    uint32_t crc = (n_args > 1) ? trezor_obj_get_uint(args[1]) : 0;
     crc = crc32(bufinfo.buf, bufinfo.len, crc ^ 0xffffffff);
     return mp_obj_new_int_from_uint(crc ^ 0xffffffff);
 }

--- a/embed/extmod/modtrezorcrypto/modtrezorcrypto-pbkdf2.h
+++ b/embed/extmod/modtrezorcrypto/modtrezorcrypto-pbkdf2.h
@@ -85,7 +85,7 @@ STATIC mp_obj_t mod_trezorcrypto_Pbkdf2_make_new(const mp_obj_type_t *type, size
 ///     '''
 STATIC mp_obj_t mod_trezorcrypto_Pbkdf2_update(mp_obj_t self, mp_obj_t iterations) {
     mp_obj_Pbkdf2_t *o = MP_OBJ_TO_PTR(self);
-    uint32_t iter = mp_obj_get_int(iterations);
+    uint32_t iter = trezor_obj_get_uint(iterations);
     if (o->prf == 256) {
         pbkdf2_hmac_sha256_Update(&(o->ctx256), iter);
     }

--- a/embed/extmod/modtrezorcrypto/modtrezorcrypto-random.h
+++ b/embed/extmod/modtrezorcrypto/modtrezorcrypto-random.h
@@ -41,7 +41,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(mod_trezorcrypto_random_uniform_obj, mod_trezor
 ///     Generate random bytes sequence of length len.
 ///     '''
 STATIC mp_obj_t mod_trezorcrypto_random_bytes(mp_obj_t len) {
-    uint32_t l = mp_obj_get_int(len);
+    uint32_t l = trezor_obj_get_uint(len);
     if (l > 1024) {
         mp_raise_ValueError("Maximum requested size is 1024");
     }

--- a/embed/extmod/modtrezorcrypto/modtrezorcrypto-random.h
+++ b/embed/extmod/modtrezorcrypto/modtrezorcrypto-random.h
@@ -19,6 +19,8 @@
 
 #include "py/objstr.h"
 
+#include "embed/extmod/trezorobj.h"
+
 #include "rand.h"
 
 /// def uniform(n: int) -> int:
@@ -26,7 +28,7 @@
 ///     Compute uniform random number from interval 0 ... n - 1.
 ///     '''
 STATIC mp_obj_t mod_trezorcrypto_random_uniform(mp_obj_t n) {
-    uint32_t nn = mp_obj_get_int_truncated(n);
+    uint32_t nn = trezor_obj_get_uint(n);
     if (nn == 0) {
         mp_raise_ValueError("Maximum can't be zero");
     }

--- a/embed/extmod/modtrezorio/modtrezorio-flash.h
+++ b/embed/extmod/modtrezorio/modtrezorio-flash.h
@@ -19,6 +19,8 @@
 
 #include "flash.h"
 
+#include "embed/extmod/trezorobj.h"
+
 /// class FlashOTP:
 ///     '''
 ///     '''
@@ -41,8 +43,8 @@ STATIC mp_obj_t mod_trezorio_FlashOTP_make_new(const mp_obj_type_t *type, size_t
 ///     Writes data to OTP flash
 ///     '''
 STATIC mp_obj_t mod_trezorio_FlashOTP_write(size_t n_args, const mp_obj_t *args) {
-    uint8_t block = mp_obj_get_int(args[1]);
-    uint8_t offset = mp_obj_get_int(args[2]);
+    uint8_t block = trezor_obj_get_uint8(args[1]);
+    uint8_t offset = trezor_obj_get_uint8(args[2]);
     mp_buffer_info_t data;
     mp_get_buffer_raise(args[3], &data, MP_BUFFER_READ);
     if (sectrue != flash_otp_write(block, offset, data.buf, data.len)) {
@@ -57,8 +59,8 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(mod_trezorio_FlashOTP_write_obj, 4, 4
 ///     Reads data from OTP flash
 ///     '''
 STATIC mp_obj_t mod_trezorio_FlashOTP_read(size_t n_args, const mp_obj_t *args) {
-    uint8_t block = mp_obj_get_int(args[1]);
-    uint8_t offset = mp_obj_get_int(args[2]);
+    uint8_t block = trezor_obj_get_uint8(args[1]);
+    uint8_t offset = trezor_obj_get_uint8(args[2]);
     mp_buffer_info_t data;
     mp_get_buffer_raise(args[3], &data, MP_BUFFER_WRITE);
     if (sectrue != flash_otp_read(block, offset, data.buf, data.len)) {
@@ -73,7 +75,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(mod_trezorio_FlashOTP_read_obj, 4, 4,
 ///     Lock OTP flash block
 ///     '''
 STATIC mp_obj_t mod_trezorio_FlashOTP_lock(mp_obj_t self, mp_obj_t block) {
-    uint8_t b = mp_obj_get_int(block);
+    uint8_t b = trezor_obj_get_uint8(block);
     if (sectrue != flash_otp_lock(b)) {
         mp_raise_ValueError("lock failed");
     }
@@ -86,7 +88,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(mod_trezorio_FlashOTP_lock_obj, mod_trezorio_Fl
 ///     Is OTP flash block locked?
 ///     '''
 STATIC mp_obj_t mod_trezorio_FlashOTP_is_locked(mp_obj_t self, mp_obj_t block) {
-    uint8_t b = mp_obj_get_int(block);
+    uint8_t b = trezor_obj_get_uint8(block);
     return flash_otp_is_locked(b) ? mp_const_true : mp_const_false;
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(mod_trezorio_FlashOTP_is_locked_obj, mod_trezorio_FlashOTP_is_locked);

--- a/embed/extmod/modtrezorio/modtrezorio-poll.h
+++ b/embed/extmod/modtrezorio/modtrezorio-poll.h
@@ -51,7 +51,7 @@ STATIC mp_obj_t mod_trezorio_poll(mp_obj_t ifaces, mp_obj_t list_ref, mp_obj_t t
         mp_raise_TypeError("invalid list_ref");
     }
 
-    const mp_uint_t timeout = mp_obj_get_int(timeout_us);
+    const mp_uint_t timeout = trezor_obj_get_uint(timeout_us);
     const mp_uint_t deadline = mp_hal_ticks_us() + timeout;
     mp_obj_iter_buf_t iterbuf;
 

--- a/embed/extmod/modtrezorio/modtrezorio-poll.h
+++ b/embed/extmod/modtrezorio/modtrezorio-poll.h
@@ -20,6 +20,8 @@
 #include <string.h>
 #include <unistd.h>
 
+#include "embed/extmod/trezorobj.h"
+
 #include "usb.h"
 
 #define TOUCH_IFACE (255)
@@ -57,7 +59,7 @@ STATIC mp_obj_t mod_trezorio_poll(mp_obj_t ifaces, mp_obj_t list_ref, mp_obj_t t
         mp_obj_t iter = mp_getiter(ifaces, &iterbuf);
         mp_obj_t item;
         while ((item = mp_iternext(iter)) != MP_OBJ_STOP_ITERATION) {
-            const mp_uint_t i = mp_obj_int_get_truncated(item);
+            const mp_uint_t i = trezor_obj_get_uint(item);
             const mp_uint_t iface = i & 0x00FF;
             const mp_uint_t mode = i & 0xFF00;
 

--- a/embed/extmod/modtrezorio/modtrezorio-sdcard.h
+++ b/embed/extmod/modtrezorio/modtrezorio-sdcard.h
@@ -19,6 +19,8 @@
 
 #include "sdcard.h"
 
+#include "embed/extmod/trezorobj.h"
+
 /// class SDCard:
 ///     '''
 ///     '''
@@ -79,9 +81,10 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(mod_trezorio_SDCard_capacity_obj, mod_trezorio_
 ///     Returns True if in case of success, False otherwise.
 ///     '''
 STATIC mp_obj_t mod_trezorio_SDCard_read(mp_obj_t self, mp_obj_t block_num, mp_obj_t buf) {
+    uint32_t block = trezor_obj_get_uint(block_num);
     mp_buffer_info_t bufinfo;
     mp_get_buffer_raise(buf, &bufinfo, MP_BUFFER_WRITE);
-    return mp_obj_new_bool(sdcard_read_blocks(bufinfo.buf, mp_obj_get_int(block_num), bufinfo.len / SDCARD_BLOCK_SIZE));
+    return mp_obj_new_bool(sdcard_read_blocks(bufinfo.buf, block, bufinfo.len / SDCARD_BLOCK_SIZE));
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_3(mod_trezorio_SDCard_read_obj, mod_trezorio_SDCard_read);
 
@@ -92,9 +95,10 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_3(mod_trezorio_SDCard_read_obj, mod_trezorio_SDCa
 ///     Returns True if in case of success, False otherwise.
 ///     '''
 STATIC mp_obj_t mod_trezorio_SDCard_write(mp_obj_t self, mp_obj_t block_num, mp_obj_t buf) {
+    uint32_t block = trezor_obj_get_uint(block_num);
     mp_buffer_info_t bufinfo;
     mp_get_buffer_raise(buf, &bufinfo, MP_BUFFER_READ);
-    return mp_obj_new_bool(sdcard_write_blocks(bufinfo.buf, mp_obj_get_int(block_num), bufinfo.len / SDCARD_BLOCK_SIZE));
+    return mp_obj_new_bool(sdcard_write_blocks(bufinfo.buf, block, bufinfo.len / SDCARD_BLOCK_SIZE));
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_3(mod_trezorio_SDCard_write_obj, mod_trezorio_SDCard_write);
 

--- a/embed/extmod/modtrezorutils/modtrezorutils.c
+++ b/embed/extmod/modtrezorutils/modtrezorutils.c
@@ -23,6 +23,8 @@
 
 #if MICROPY_PY_TREZORUTILS
 
+#include "embed/extmod/trezorobj.h"
+
 #include <string.h>
 #include "common.h"
 
@@ -67,22 +69,14 @@ STATIC mp_obj_t mod_trezorutils_memcpy(size_t n_args, const mp_obj_t *args) {
 
     mp_buffer_info_t dst;
     mp_get_buffer_raise(args[0], &dst, MP_BUFFER_WRITE);
-    int dst_ofs = mp_obj_get_int(args[1]);
-    if (dst_ofs < 0) {
-        mp_raise_ValueError("Invalid dst offset (has to be >= 0)");
-    }
+    uint32_t dst_ofs = trezor_obj_get_uint(args[1]);
 
     mp_buffer_info_t src;
     mp_get_buffer_raise(args[2], &src, MP_BUFFER_READ);
-    int src_ofs = mp_obj_get_int(args[3]);
-    if (src_ofs < 0) {
-        mp_raise_ValueError("Invalid src offset (has to be >= 0)");
-    }
+    uint32_t src_ofs = trezor_obj_get_uint(args[3]);
 
-    int n = mp_obj_get_int(args[4]);
-    if (n < 0) {
-        mp_raise_ValueError("Invalid byte count (has to be >= 0)");
-    }
+    uint32_t n = trezor_obj_get_uint(args[4]);
+
     size_t dst_rem = (dst_ofs < dst.len) ? dst.len - dst_ofs : 0;
     size_t src_rem = (src_ofs < src.len) ? src.len - src_ofs : 0;
     size_t ncpy = MIN(n, MIN(src_rem, dst_rem));

--- a/embed/extmod/trezorobj.h
+++ b/embed/extmod/trezorobj.h
@@ -69,4 +69,12 @@ static inline mp_uint_t trezor_obj_get_uint(mp_obj_t obj) {
     }
 }
 
+static inline uint8_t trezor_obj_get_uint8(mp_obj_t obj) {
+    mp_uint_t u = trezor_obj_get_uint(obj);
+    if (u > 0xFF) {
+        mp_raise_msg(&mp_type_OverflowError, "value does not fit into byte type");
+    }
+    return u;
+}
+
 #endif

--- a/embed/extmod/trezorobj.h
+++ b/embed/extmod/trezorobj.h
@@ -1,0 +1,72 @@
+/*
+ * This file is part of the TREZOR project, https://trezor.io/
+ *
+ * Copyright (c) SatoshiLabs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "py/runtime.h"
+#include "py/objint.h"
+
+#ifndef __TREZOROBJ_H__
+#define __TREZOROBJ_H__
+
+#if MICROPY_LONGINT_IMPL != MICROPY_LONGINT_IMPL_MPZ
+#error Use MPZ for MicroPython long int implementation.
+#endif
+
+// Casts int object into mp_int_t, without any conversions. Raises if object is
+// not int or if it does not fit into mp_int_t representation.
+static inline mp_int_t trezor_obj_get_int(mp_obj_t obj) {
+    if (MP_OBJ_IS_SMALL_INT(obj)) {
+        mp_int_t i = MP_OBJ_SMALL_INT_VALUE(obj);
+        return i;
+    }
+    else if (MP_OBJ_IS_TYPE(obj, &mp_type_int)) {
+        mp_int_t i = 0;
+        mp_obj_int_t *self = MP_OBJ_TO_PTR(obj);
+        if (!mpz_as_int_checked(&self->mpz, &i)) {
+            mp_raise_msg(&mp_type_OverflowError, "value does not fit into signed int type");
+        }
+        return i;
+    }
+    else {
+        mp_raise_TypeError("value is not int");
+    }
+}
+
+// Casts int object into mp_uint_t, without any conversions. Raises if object is
+// not int or if it does not fit into mp_uint_t representation (or is less than
+// 0).
+static inline mp_uint_t trezor_obj_get_uint(mp_obj_t obj) {
+    if (MP_OBJ_IS_SMALL_INT(obj)) {
+        mp_int_t i = MP_OBJ_SMALL_INT_VALUE(obj);
+        mp_uint_t u = i;
+        return u;
+    }
+    else if (MP_OBJ_IS_TYPE(obj, &mp_type_int)) {
+        mp_uint_t u = 0;
+        mp_obj_int_t *self = MP_OBJ_TO_PTR(obj);
+        if (!mpz_as_uint_checked(&self->mpz, &u)) {
+            mp_raise_msg(&mp_type_OverflowError, "value does not fit into unsigned int type");
+        }
+        return u;
+    }
+    else {
+        mp_raise_TypeError("value is not int");
+    }
+}
+
+#endif


### PR DESCRIPTION
Continuing discussion from #191.

This PR replaces all occurrences of `mp_obj_get_int_truncated` and `mp_obj_int_get_truncated` with new helper functions.

Remaining work:

- [x] Replace `mp_obj_get_int` for unsigned cases
- [ ] Tests