### PR TITLE
RSK uses a different checksum encoding.

### DIFF
--- a/src/apps/ethereum/get_address.py
+++ b/src/apps/ethereum/get_address.py
@@ -26,12 +26,15 @@ async def ethereum_get_address(ctx, msg):
     return EthereumAddress(address=address)
 
 
-def _ethereum_address_hex(address):
+def _ethereum_address_hex(address, chain_id=None):
     from ubinascii import hexlify
     from trezor.crypto.hashlib import sha3_256
 
+    applying_chain_ids = [30, 31]
+
     hx = hexlify(address).decode()
-    hs = sha3_256(hx).digest(True)
+    prefix = str(chain_id) + '0x' if (chain_id in applying_chain_ids) else ''
+    hs = sha3_256(prefix + hx).digest(True)
     h = ''
 
     for i in range(20):

--- a/src/apps/ethereum/get_address.py
+++ b/src/apps/ethereum/get_address.py
@@ -16,10 +16,7 @@ async def ethereum_get_address(ctx, msg):
     address = sha3_256(public_key[1:]).digest(True)[12:]  # Keccak
 
     if msg.show_display:
-        slip44_networks = { 137: 30, 37310: 31 }
-        slip44_network_id = address_n[1] - 2**31
-
-        chain_id = slip44_networks.get(slip44_network_id, 0)
+        chain_id = decode_chain_id(address_n)
 
         hex_addr = _ethereum_address_hex(address, chain_id)
         while True:
@@ -29,6 +26,13 @@ async def ethereum_get_address(ctx, msg):
                 break
 
     return EthereumAddress(address=address)
+
+
+def decode_chain_id(dpath):
+    slip44_networks = { 137: 30, 37310: 31 }
+    slip44_network_id = dpath[1] - 2**31
+
+    return slip44_networks.get(slip44_network_id, 0)
 
 
 def _ethereum_address_hex(address, chain_id=None):

--- a/src/apps/ethereum/get_address.py
+++ b/src/apps/ethereum/get_address.py
@@ -28,17 +28,15 @@ async def ethereum_get_address(ctx, msg):
     return EthereumAddress(address=address)
 
 
-''' <SLIP-44 coin ID, EIP-155 chain ID> '''
+''' <SLIP-44 coin ID (2^31 to right), EIP-155 chain ID> '''
 rksip60_applying_chains = {
-    137: 30, # RSK MainNet
-    37310: 31 # RSK TestNet
+    2147483785: 30, # RSK MainNet
+    2147520958: 31 # RSK TestNet
 }
 
 
 def decode_chain_id(dpath):
-    slip44_network_id = dpath[1] - 2**31
-
-    return rksip60_applying_chains.get(slip44_network_id, 0)
+    return rksip60_applying_chains.get(dpath[1], 0)
 
 
 def _ethereum_address_hex(address, chain_id=None):

--- a/src/apps/ethereum/get_address.py
+++ b/src/apps/ethereum/get_address.py
@@ -28,18 +28,24 @@ async def ethereum_get_address(ctx, msg):
     return EthereumAddress(address=address)
 
 
+''' <SLIP-44 coin ID, EIP-155 chain ID> '''
+rksip60_applying_chains = {
+    137: 30, # RSK MainNet
+    37310: 31 # RSK TestNet
+}
+
+
 def decode_chain_id(dpath):
-    slip44_networks = { 137: 30, 37310: 31 }
     slip44_network_id = dpath[1] - 2**31
 
-    return slip44_networks.get(slip44_network_id, 0)
+    return rksip60_applying_chains.get(slip44_network_id, 0)
 
 
 def _ethereum_address_hex(address, chain_id=None):
     from ubinascii import hexlify
     from trezor.crypto.hashlib import sha3_256
 
-    applying_chain_ids = [30, 31]
+    applying_chain_ids = rksip60_applying_chains.values()
 
     hx = hexlify(address).decode()
     prefix = str(chain_id) + '0x' if (chain_id in applying_chain_ids) else ''

--- a/src/apps/ethereum/get_address.py
+++ b/src/apps/ethereum/get_address.py
@@ -16,7 +16,12 @@ async def ethereum_get_address(ctx, msg):
     address = sha3_256(public_key[1:]).digest(True)[12:]  # Keccak
 
     if msg.show_display:
-        hex_addr = _ethereum_address_hex(address)
+        slip44_networks = { 137: 30, 37310: 31 }
+        slip44_network_id = address_n[1] - 2**31
+
+        chain_id = slip44_networks.get(slip44_network_id, 0)
+
+        hex_addr = _ethereum_address_hex(address, chain_id)
         while True:
             if await _show_address(ctx, hex_addr):
                 break

--- a/src/apps/ethereum/layout.py
+++ b/src/apps/ethereum/layout.py
@@ -11,7 +11,7 @@ from .get_address import _ethereum_address_hex
 
 async def require_confirm_tx(ctx, to, value, chain_id, token=None, tx_type=None):
     if to:
-        str_to = _ethereum_address_hex(to)
+        str_to = _ethereum_address_hex(to, chain_id)
     else:
         str_to = 'new contract?'
     content = Text('Confirm sending', ui.ICON_SEND,


### PR DESCRIPTION
### General
RSK uses a different address checksum encoding, not the same as Etherum. It's described in RSKIP-60, and it's compatible with EIP-55 ecnoding.

### Solution
- Implement RSK checksum in Ethereum `require_confirm_tx`
- Implement RSK checksum in `EthereumGetAddress`
     1. Derive node id from Derivation Path
     2. Apply checksum