### PR TITLE
NEM: display QR code in get address and display address refactoring

### DIFF
--- a/src/apps/common/display_address.py
+++ b/src/apps/common/display_address.py
@@ -1,0 +1,39 @@
+from micropython import const
+from apps.common.confirm import confirm
+from trezor import ui
+from trezor.messages import ButtonRequestType
+from trezor.ui.container import Container
+from trezor.ui.qr import Qr
+from trezor.ui.text import Text
+from trezor.utils import chunks
+
+
+async def show_address(ctx, address: str):
+    lines = split_address(address)
+    content = Text('Confirm address', ui.ICON_RECEIVE, ui.MONO, *lines, icon_color=ui.GREEN)
+    return await confirm(
+        ctx,
+        content,
+        code=ButtonRequestType.Address,
+        cancel='QR',
+        cancel_style=ui.BTN_KEY)
+
+
+async def show_qr(ctx, address: str):
+    qr_x = const(120)
+    qr_y = const(115)
+    qr_coef = const(4)
+
+    content = Container(
+        Qr(address, (qr_x, qr_y), qr_coef),
+        Text('Confirm address', ui.ICON_RECEIVE, ui.MONO, icon_color=ui.GREEN))
+    return await confirm(
+        ctx,
+        content,
+        code=ButtonRequestType.Address,
+        cancel='Address',
+        cancel_style=ui.BTN_KEY)
+
+
+def split_address(address: str):
+    return chunks(address, 17)

--- a/src/apps/ethereum/get_address.py
+++ b/src/apps/ethereum/get_address.py
@@ -1,4 +1,4 @@
-from apps.wallet.get_address import _show_address, _show_qr
+from apps.common.display_address import show_address, show_qr
 from apps.ethereum import networks
 
 
@@ -21,9 +21,9 @@ async def ethereum_get_address(ctx, msg):
         hex_addr = _ethereum_address_hex(address, network)
 
         while True:
-            if await _show_address(ctx, hex_addr):
+            if await show_address(ctx, hex_addr):
                 break
-            if await _show_qr(ctx, hex_addr):
+            if await show_qr(ctx, hex_addr):
                 break
 
     return EthereumAddress(address=address)

--- a/src/apps/ethereum/verify_message.py
+++ b/src/apps/ethereum/verify_message.py
@@ -5,9 +5,9 @@ from trezor import ui
 from trezor.ui.text import Text
 from trezor.messages.Success import Success
 from apps.common.confirm import require_confirm
+from apps.common.display_address import split_address
 from apps.common.signverify import split_message
 from apps.ethereum.sign_message import message_digest
-from apps.wallet.get_address import _split_address
 
 
 async def ethereum_verify_message(ctx, msg):
@@ -32,7 +32,7 @@ async def ethereum_verify_message(ctx, msg):
 
 
 async def require_confirm_verify_message(ctx, address, message):
-    lines = _split_address(address)
+    lines = split_address(address)
     content = Text('Confirm address', ui.ICON_DEFAULT, ui.MONO, *lines)
     await require_confirm(ctx, content)
 

--- a/src/apps/lisk/get_address.py
+++ b/src/apps/lisk/get_address.py
@@ -1,5 +1,5 @@
 from apps.common import seed
-from apps.wallet.get_address import _show_address, _show_qr
+from apps.common.display_address import show_address, show_qr
 from trezor.messages.LiskAddress import LiskAddress
 
 from .helpers import LISK_CURVE, get_address_from_public_key
@@ -15,9 +15,9 @@ async def layout_lisk_get_address(ctx, msg):
 
     if msg.show_display:
         while True:
-            if await _show_address(ctx, address):
+            if await show_address(ctx, address):
                 break
-            if await _show_qr(ctx, address):
+            if await show_qr(ctx, address):
                 break
 
     return LiskAddress(address=address)

--- a/src/apps/nem/get_address.py
+++ b/src/apps/nem/get_address.py
@@ -4,7 +4,8 @@ from trezor.messages.NEMAddress import NEMAddress
 from trezor.ui.text import Text
 
 from apps.common import seed
-from apps.common.confirm import require_confirm
+from apps.common.confirm import confirm
+from apps.common.display_address import show_qr
 
 from .layout import split_address
 from .helpers import get_network_str, NEM_CURVE
@@ -17,16 +18,26 @@ async def get_address(ctx, msg):
     address = node.nem_address(network)
 
     if msg.show_display:
-        await _require_confirm_address(ctx, address, network)
+
+        while True:
+            if await _show_address(ctx, address, network):
+                break
+            if await show_qr(ctx, address.upper()):
+                break
 
     return NEMAddress(address=address)
 
 
-async def _require_confirm_address(ctx, address: str, network: int):
+async def _show_address(ctx, address: str, network: int):
     lines = split_address(address)
     content = Text(
-        'Export NEM address', ui.ICON_RECEIVE,
+        'Confirm address', ui.ICON_RECEIVE,
         ui.NORMAL, '%s network' % get_network_str(network),
         ui.MONO, *lines,
         icon_color=ui.GREEN)
-    await require_confirm(ctx, content, code=ButtonRequestType.Address)
+    return await confirm(
+            ctx,
+            content,
+            code=ButtonRequestType.Address,
+            cancel='QR',
+            cancel_style=ui.BTN_KEY)

--- a/src/apps/wallet/get_address.py
+++ b/src/apps/wallet/get_address.py
@@ -1,13 +1,7 @@
-from micropython import const
-from trezor import ui
-from trezor.messages import ButtonRequestType, InputScriptType
+from trezor.messages import InputScriptType
 from trezor.messages.Address import Address
-from trezor.ui.container import Container
-from trezor.ui.qr import Qr
-from trezor.ui.text import Text
-from trezor.utils import chunks
 from apps.common import coins, seed
-from apps.common.confirm import confirm
+from apps.common.display_address import show_qr, show_address
 from apps.wallet.sign_tx import addresses
 
 
@@ -21,40 +15,9 @@ async def get_address(ctx, msg):
 
     if msg.show_display:
         while True:
-            if await _show_address(ctx, address_short):
+            if await show_address(ctx, address_short):
                 break
-            if await _show_qr(ctx, address.upper() if msg.script_type == InputScriptType.SPENDWITNESS else address):
+            if await show_qr(ctx, address.upper() if msg.script_type == InputScriptType.SPENDWITNESS else address):
                 break
 
     return Address(address=address)
-
-
-async def _show_address(ctx, address: str):
-    lines = _split_address(address)
-    content = Text('Confirm address', ui.ICON_RECEIVE, ui.MONO, *lines, icon_color=ui.GREEN)
-    return await confirm(
-        ctx,
-        content,
-        code=ButtonRequestType.Address,
-        cancel='QR',
-        cancel_style=ui.BTN_KEY)
-
-
-async def _show_qr(ctx, address: str):
-    qr_x = const(120)
-    qr_y = const(115)
-    qr_coef = const(4)
-
-    content = Container(
-        Qr(address, (qr_x, qr_y), qr_coef),
-        Text('Confirm address', ui.ICON_RECEIVE, ui.MONO, icon_color=ui.GREEN))
-    return await confirm(
-        ctx,
-        content,
-        code=ButtonRequestType.Address,
-        cancel='Address',
-        cancel_style=ui.BTN_KEY)
-
-
-def _split_address(address: str):
-    return chunks(address, 17)

--- a/src/apps/wallet/verify_message.py
+++ b/src/apps/wallet/verify_message.py
@@ -5,9 +5,9 @@ from trezor.messages.Success import Success
 from trezor.ui.text import Text
 from apps.common import coins
 from apps.common.confirm import require_confirm
+from apps.common.display_address import split_address
 from apps.common.signverify import message_digest, split_message
 from apps.wallet.sign_tx.addresses import address_pkh, address_p2wpkh_in_p2sh, address_p2wpkh, address_to_cashaddr
-from apps.wallet.get_address import _split_address
 
 
 async def verify_message(ctx, msg):
@@ -59,7 +59,7 @@ async def verify_message(ctx, msg):
 
 
 async def require_confirm_verify_message(ctx, address, message):
-    lines = _split_address(address)
+    lines = split_address(address)
     content = Text('Confirm address', ui.ICON_DEFAULT, ui.MONO, *lines)
     await require_confirm(ctx, content)
 


### PR DESCRIPTION
@jpochyla I've moved the `show_qr` and `show_address` to `apps.common.display_address` (not 100% sure about the name), because it's shared between the apps. I think this is better than grabbing it from `apps.wallet`.

Also as part of that, I've added a QR code displaying into NEM's Get Address, as instructed in #227.