### PR TITLE
RSKIP-60 based checksum address encoding

### DIFF
--- a/src/apps/ethereum/layout.py
+++ b/src/apps/ethereum/layout.py
@@ -12,7 +12,7 @@ from apps.ethereum.get_address import _ethereum_address_hex
 
 async def require_confirm_tx(ctx, to, value, chain_id, token=None, tx_type=None):
     if to:
-        str_to = _ethereum_address_hex(to)
+        str_to = _ethereum_address_hex(to, chain_id)
     else:
         str_to = 'new contract?'
     content = Text('Confirm sending', ui.ICON_SEND,

--- a/src/apps/nem/validators.py
+++ b/src/apps/nem/validators.py
@@ -1,5 +1,7 @@
 from trezor.crypto import nem
+from trezor.wire import ProcessError
 from trezor.messages import NEMModificationType
+from trezor.messages import NEMSupplyChangeType
 from trezor.messages.NEMSignTx import (NEMAggregateModification,
                                        NEMImportanceTransfer,
                                        NEMMosaicCreation,
@@ -15,7 +17,7 @@ from .helpers import (NEM_MAX_DIVISIBILITY, NEM_MAX_ENCRYPTED_PAYLOAD_SIZE,
 
 def validate(msg: NEMSignTx):
     if msg.transaction is None:
-        raise ValueError('No common provided')
+        raise ProcessError('No common provided')
 
     _validate_single_tx(msg)
     _validate_common(msg.transaction)
@@ -24,7 +26,7 @@ def validate(msg: NEMSignTx):
         _validate_common(msg.multisig, True)
         _validate_multisig(msg.multisig, msg.transaction.network)
     if not msg.multisig and msg.cosigning:
-        raise ValueError('No multisig transaction to cosign')
+        raise ProcessError('No multisig transaction to cosign')
 
     if msg.transfer:
         _validate_transfer(msg.transfer, msg.transaction.network)
@@ -44,7 +46,7 @@ def validate_network(network: int) -> int:
     if network is None:
         return NEM_NETWORK_MAINNET
     if network not in (NEM_NETWORK_MAINNET, NEM_NETWORK_TESTNET, NEM_NETWORK_MIJIN):
-        raise ValueError('Invalid NEM network')
+        raise ProcessError('Invalid NEM network')
     return network
 
 
@@ -58,9 +60,9 @@ def _validate_single_tx(msg: NEMSignTx):
         bool(msg.aggregate_modification) + \
         bool(msg.importance_transfer)
     if tx_count == 0:
-        raise ValueError('No transaction provided')
+        raise ProcessError('No transaction provided')
     if tx_count > 1:
-        raise ValueError('More than one transaction provided')
+        raise ProcessError('More than one transaction provided')
 
 
 def _validate_common(common: NEMTransactionCommon, inner: bool = False):
@@ -75,16 +77,16 @@ def _validate_common(common: NEMTransactionCommon, inner: bool = False):
         err = 'deadline'
 
     if not inner and common.signer:
-        raise ValueError('Signer not allowed in outer transaction')
+        raise ProcessError('Signer not allowed in outer transaction')
 
     if inner and common.signer is None:
         err = 'signer'
 
     if err:
         if inner:
-            raise ValueError('No %s provided in inner transaction' % err)
+            raise ProcessError('No %s provided in inner transaction' % err)
         else:
-            raise ValueError('No %s provided' % err)
+            raise ProcessError('No %s provided' % err)
 
     if common.signer is not None:
         _validate_public_key(common.signer, 'Invalid signer public key in inner transaction')
@@ -92,20 +94,20 @@ def _validate_common(common: NEMTransactionCommon, inner: bool = False):
 
 def _validate_public_key(public_key: bytes, err_msg: str):
     if not public_key:
-        raise ValueError('%s (none provided)' % err_msg)
+        raise ProcessError('%s (none provided)' % err_msg)
     if len(public_key) != NEM_PUBLIC_KEY_SIZE:
-        raise ValueError('%s (invalid length)' % err_msg)
+        raise ProcessError('%s (invalid length)' % err_msg)
 
 
 def _validate_importance_transfer(importance_transfer: NEMImportanceTransfer):
     if importance_transfer.mode is None:
-        raise ValueError('No mode provided')
+        raise ProcessError('No mode provided')
     _validate_public_key(importance_transfer.public_key, 'Invalid remote account public key provided')
 
 
 def _validate_multisig(multisig: NEMTransactionCommon, network: int):
     if multisig.network != network:
-        raise ValueError('Inner transaction network is different')
+        raise ProcessError('Inner transaction network is different')
     _validate_public_key(multisig.signer, 'Invalid multisig signer public key provided')
 
 
@@ -114,124 +116,128 @@ def _validate_aggregate_modification(
         creation: bool = False):
 
     if creation and not aggregate_modification.modifications:
-        raise ValueError('No modifications provided')
+        raise ProcessError('No modifications provided')
 
     for m in aggregate_modification.modifications:
         if not m.type:
-            raise ValueError('No modification type provided')
+            raise ProcessError('No modification type provided')
         if m.type not in (
             NEMModificationType.CosignatoryModification_Add,
             NEMModificationType.CosignatoryModification_Delete
         ):
-            raise ValueError('Unknown aggregate modification')
+            raise ProcessError('Unknown aggregate modification')
         if creation and m.type == NEMModificationType.CosignatoryModification_Delete:
-            raise ValueError('Cannot remove cosignatory when converting account')
+            raise ProcessError('Cannot remove cosignatory when converting account')
         _validate_public_key(m.public_key, 'Invalid cosignatory public key provided')
 
 
 def _validate_supply_change(supply_change: NEMMosaicSupplyChange):
     if supply_change.namespace is None:
-        raise ValueError('No namespace provided')
+        raise ProcessError('No namespace provided')
     if supply_change.mosaic is None:
-        raise ValueError('No mosaic provided')
+        raise ProcessError('No mosaic provided')
     if supply_change.type is None:
-        raise ValueError('No type provided')
+        raise ProcessError('No type provided')
+    elif supply_change.type not in [NEMSupplyChangeType.SupplyChange_Decrease, NEMSupplyChangeType.SupplyChange_Increase]:
+        raise ProcessError('Invalid supply change type')
     if supply_change.delta is None:
-        raise ValueError('No delta provided')
+        raise ProcessError('No delta provided')
 
 
 def _validate_mosaic_creation(mosaic_creation: NEMMosaicCreation, network: int):
     if mosaic_creation.definition is None:
-        raise ValueError('No mosaic definition provided')
+        raise ProcessError('No mosaic definition provided')
     if mosaic_creation.sink is None:
-        raise ValueError('No creation sink provided')
+        raise ProcessError('No creation sink provided')
     if mosaic_creation.fee is None:
-        raise ValueError('No creation sink fee provided')
+        raise ProcessError('No creation sink fee provided')
 
     if not nem.validate_address(mosaic_creation.sink, network):
-        raise ValueError('Invalid creation sink address')
+        raise ProcessError('Invalid creation sink address')
 
     if mosaic_creation.definition.name is not None:
-        raise ValueError('Name not allowed in mosaic creation transactions')
+        raise ProcessError('Name not allowed in mosaic creation transactions')
     if mosaic_creation.definition.ticker is not None:
-        raise ValueError('Ticker not allowed in mosaic creation transactions')
+        raise ProcessError('Ticker not allowed in mosaic creation transactions')
     if mosaic_creation.definition.networks:
-        raise ValueError('Networks not allowed in mosaic creation transactions')
+        raise ProcessError('Networks not allowed in mosaic creation transactions')
 
     if mosaic_creation.definition.namespace is None:
-        raise ValueError('No mosaic namespace provided')
+        raise ProcessError('No mosaic namespace provided')
     if mosaic_creation.definition.mosaic is None:
-        raise ValueError('No mosaic name provided')
+        raise ProcessError('No mosaic name provided')
 
     if mosaic_creation.definition.supply is not None and mosaic_creation.definition.divisibility is None:
-        raise ValueError('Definition divisibility needs to be provided when supply is')
+        raise ProcessError('Definition divisibility needs to be provided when supply is')
     if mosaic_creation.definition.supply is None and mosaic_creation.definition.divisibility is not None:
-        raise ValueError('Definition supply needs to be provided when divisibility is')
+        raise ProcessError('Definition supply needs to be provided when divisibility is')
 
     if mosaic_creation.definition.levy is not None:
         if mosaic_creation.definition.fee is None:
-            raise ValueError('No levy fee provided')
+            raise ProcessError('No levy fee provided')
         if mosaic_creation.definition.levy_address is None:
-            raise ValueError('No levy address provided')
+            raise ProcessError('No levy address provided')
         if mosaic_creation.definition.levy_namespace is None:
-            raise ValueError('No levy namespace provided')
+            raise ProcessError('No levy namespace provided')
         if mosaic_creation.definition.levy_mosaic is None:
-            raise ValueError('No levy mosaic name provided')
+            raise ProcessError('No levy mosaic name provided')
 
         if mosaic_creation.definition.divisibility is None:
-            raise ValueError('No divisibility provided')
+            raise ProcessError('No divisibility provided')
         if mosaic_creation.definition.supply is None:
-            raise ValueError('No supply provided')
+            raise ProcessError('No supply provided')
         if mosaic_creation.definition.mutable_supply is None:
-            raise ValueError('No supply mutability provided')
+            raise ProcessError('No supply mutability provided')
         if mosaic_creation.definition.transferable is None:
-            raise ValueError('No mosaic transferability provided')
+            raise ProcessError('No mosaic transferability provided')
         if mosaic_creation.definition.description is None:
-            raise ValueError('No description provided')
+            raise ProcessError('No description provided')
 
         if mosaic_creation.definition.divisibility > NEM_MAX_DIVISIBILITY:
-            raise ValueError('Invalid divisibility provided')
+            raise ProcessError('Invalid divisibility provided')
         if mosaic_creation.definition.supply > NEM_MAX_SUPPLY:
-            raise ValueError('Invalid supply provided')
+            raise ProcessError('Invalid supply provided')
 
         if not nem.validate_address(mosaic_creation.definition.levy_address, network):
-            raise ValueError('Invalid levy address')
+            raise ProcessError('Invalid levy address')
 
 
 def _validate_provision_namespace(provision_namespace: NEMProvisionNamespace, network: int):
     if provision_namespace.namespace is None:
-        raise ValueError('No namespace provided')
+        raise ProcessError('No namespace provided')
     if provision_namespace.sink is None:
-        raise ValueError('No rental sink provided')
+        raise ProcessError('No rental sink provided')
     if provision_namespace.fee is None:
-        raise ValueError('No rental sink fee provided')
+        raise ProcessError('No rental sink fee provided')
 
     if not nem.validate_address(provision_namespace.sink, network):
-        raise ValueError('Invalid rental sink address')
+        raise ProcessError('Invalid rental sink address')
 
 
 def _validate_transfer(transfer: NEMTransfer, network: int):
     if transfer.recipient is None:
-        raise ValueError('No recipient provided')
+        raise ProcessError('No recipient provided')
     if transfer.amount is None:
-        raise ValueError('No amount provided')
+        raise ProcessError('No amount provided')
 
     if transfer.public_key is not None:
         _validate_public_key(transfer.public_key, 'Invalid recipient public key')
+        if transfer.payload is None:
+            raise ProcessError('Public key provided but no payload to encrypt')
 
     if transfer.payload:
         if len(transfer.payload) > NEM_MAX_PLAIN_PAYLOAD_SIZE:
-            raise ValueError('Payload too large')
+            raise ProcessError('Payload too large')
         if transfer.public_key and len(transfer.payload) > NEM_MAX_ENCRYPTED_PAYLOAD_SIZE:
-            raise ValueError('Payload too large')
+            raise ProcessError('Payload too large')
 
     if not nem.validate_address(transfer.recipient, network):
-        raise ValueError('Invalid recipient address')
+        raise ProcessError('Invalid recipient address')
 
     for m in transfer.mosaics:
         if m.namespace is None:
-            raise ValueError('No mosaic namespace provided')
+            raise ProcessError('No mosaic namespace provided')
         if m.mosaic is None:
-            raise ValueError('No mosaic name provided')
+            raise ProcessError('No mosaic name provided')
         if m.quantity is None:
-            raise ValueError('No mosaic quantity provided')
+            raise ProcessError('No mosaic quantity provided')

--- a/src/apps/wallet/sign_tx/overwinter_zip143.py
+++ b/src/apps/wallet/sign_tx/overwinter_zip143.py
@@ -38,13 +38,13 @@ class Zip143:
         write_tx_output(self.h_outputs, txo_bin)
 
     def get_prevouts_hash(self) -> bytes:
-        return get_tx_hash(self.h_prevouts, False)
+        return get_tx_hash(self.h_prevouts)
 
     def get_sequence_hash(self) -> bytes:
-        return get_tx_hash(self.h_sequence, False)
+        return get_tx_hash(self.h_sequence)
 
     def get_outputs_hash(self) -> bytes:
-        return get_tx_hash(self.h_outputs, False)
+        return get_tx_hash(self.h_outputs)
 
     def preimage_hash(self, coin: CoinInfo, tx: SignTx, txi: TxInputType, pubkeyhash: bytes, sighash: int) -> bytes:
         h_preimage = HashWriter(blake2b, b'', 32, b'ZcashSigHash\x19\x1b\xa8\x5b')  # BRANCH_ID = 0x5ba81b19
@@ -72,7 +72,7 @@ class Zip143:
 
         write_uint32(h_preimage, txi.sequence)                        # 10d. nSequence
 
-        return get_tx_hash(h_preimage, False)
+        return get_tx_hash(h_preimage)
 
     # see https://github.com/bitcoin/bips/blob/master/bip-0143.mediawiki#specification
     # item 5 for details

--- a/src/apps/wallet/sign_tx/segwit_bip143.py
+++ b/src/apps/wallet/sign_tx/segwit_bip143.py
@@ -33,13 +33,13 @@ class Bip143:
         write_tx_output(self.h_outputs, txo_bin)
 
     def get_prevouts_hash(self) -> bytes:
-        return get_tx_hash(self.h_prevouts, True)
+        return get_tx_hash(self.h_prevouts, double=True)
 
     def get_sequence_hash(self) -> bytes:
-        return get_tx_hash(self.h_sequence, True)
+        return get_tx_hash(self.h_sequence, double=True)
 
     def get_outputs_hash(self) -> bytes:
-        return get_tx_hash(self.h_outputs, True)
+        return get_tx_hash(self.h_outputs, double=True)
 
     def preimage_hash(self, coin: CoinInfo, tx: SignTx, txi: TxInputType, pubkeyhash: bytes, sighash: int) -> bytes:
         h_preimage = HashWriter(sha256)
@@ -63,7 +63,7 @@ class Bip143:
         write_uint32(h_preimage, tx.lock_time)                        # nLockTime
         write_uint32(h_preimage, sighash)                             # nHashType
 
-        return get_tx_hash(h_preimage, True)
+        return get_tx_hash(h_preimage, double=True)
 
     # see https://github.com/bitcoin/bips/blob/master/bip-0143.mediawiki#specification
     # item 5 for details

--- a/src/apps/wallet/sign_tx/signing.py
+++ b/src/apps/wallet/sign_tx/signing.py
@@ -299,7 +299,7 @@ async def sign_tx(tx: SignTx, root: bip32.HDNode):
             write_uint32(h_sign, get_hash_type(coin))
 
             # check the control digests
-            if get_tx_hash(h_first, False) != get_tx_hash(h_second, False):
+            if get_tx_hash(h_first, False) != get_tx_hash(h_second):
                 raise SigningError(FailureType.ProcessError,
                                    'Transaction has changed during signing')
 
@@ -308,7 +308,7 @@ async def sign_tx(tx: SignTx, root: bip32.HDNode):
                 multisig_pubkey_index(txi_sign.multisig, key_sign_pub)
 
             # compute the signature from the tx digest
-            signature = ecdsa_sign(key_sign, get_tx_hash(h_sign, True))
+            signature = ecdsa_sign(key_sign, get_tx_hash(h_sign, double=True))
             tx_ser.signature_index = i_sign
             tx_ser.signature = signature
 
@@ -433,7 +433,7 @@ async def get_prevtx_output_value(coin: CoinInfo, tx_req: TxRequest, prev_hash: 
         write_bytes(txh, data)
         ofs += len(data)
 
-    if get_tx_hash(txh, True, True) != prev_hash:
+    if get_tx_hash(txh, double=True, reverse=True) != prev_hash:
         raise SigningError(FailureType.ProcessError,
                            'Encountered invalid prev_hash')
 

--- a/src/apps/wallet/sign_tx/writers.py
+++ b/src/apps/wallet/sign_tx/writers.py
@@ -109,7 +109,7 @@ def bytearray_with_cap(cap: int) -> bytearray:
 # ===
 
 
-def get_tx_hash(w, double: bool, reverse: bool=False) -> bytes:
+def get_tx_hash(w, double: bool=False, reverse: bool=False) -> bytes:
     d = w.get_digest()
     if double:
         d = sha256(d).digest()

--- a/tests/test_apps.ethereum.get_address.py
+++ b/tests/test_apps.ethereum.get_address.py
@@ -23,5 +23,40 @@ class TestEthereumGetAddress(unittest.TestCase):
             self.assertEqual(h, '0x' + s)
 
 
+    def test_ethereum_address_hex_rskip60(self):
+        # https://github.com/rsksmart/RSKIPs/blob/master/IPs/RSKIP60.md
+        rskip60_chain_30 = [
+            '0x5AaEb6053f3e94C9B9A09f33669435e7Ef1BeaeD',
+            '0xFb6916095ca1dF60BB79Ce92cE3EA74C37C5D359',
+            '0xdbf03b407C01e7cd3CbEA99509D93F8Dddc8c6fB',
+            '0xD1220A0cF47C7B9bE7a2E6ba89F429762e7b9aDB'
+        ]
+        eip55 = [
+            '0x52908400098527886E0F7030069857D2E4169EE7',
+            '0x8617E340B3D01FA5F11F306F4090FD50E238070D',
+            '0xde709f2102306220921060314715629080e2fb77',
+            '0x27b1fdb04752bbc536007a920d24acb045561c26',
+            '0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed',
+            '0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359',
+            '0xdbF03B407c01E7cD3CBea99509d93f8DDDC8C6FB',
+            '0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb',
+        ]
+        for s in rskip60_chain_30:
+            s = s[2:]
+            b = bytes([int(s[i:i + 2], 16) for i in range(0, len(s), 2)])
+            h = _ethereum_address_hex(b, 30)
+            self.assertEqual(h, '0x' + s)
+        for s in rskip60_chain_30:
+            s = s[2:]
+            b = bytes([int(s[i:i + 2], 16) for i in range(0, len(s), 2)])
+            h = _ethereum_address_hex(b, 30, True)
+            self.assertEqual(h, '0x' + s)
+        for s in eip55:
+            s = s[2:]
+            b = bytes([int(s[i:i + 2], 16) for i in range(0, len(s), 2)])
+            h = _ethereum_address_hex(b, 1)
+            self.assertEqual(h, '0x' + s)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### General
RSK uses a different address checksum encoding, not the same as Etherum. It's described in RSKIP-60, and it's compatible with EIP-55 ecnoding.

### Solution
- Implement RSK checksum in Ethereum `require_confirm_tx`
- Implement RSK checksum in `EthereumGetAddress`

### Implementation
- Line 20: SLIP-44 coin id derived from derivtion path (always positive)
- Line 37: lazy conditional avoids double checking `networks.by_`