### PR TITLE
fix: emulator docs link

### DIFF
--- a/docs/emulator.md
+++ b/docs/emulator.md
@@ -2,6 +2,6 @@
 
 ![emulator](emulator.jpg)
 
-1. [build](docs/build.md) the emulator
+1. [build](build.md) the emulator
 2. run `emu.sh`
 3. to use [bridge](https://github.com/trezor/trezord-go) with the emulator support, start it with `trezord -e 21324`


### PR DESCRIPTION
Fixes link from the `emulator.md` to `build.md`