### PR TITLE
Update RSKIP-60 checksum separator

### DIFF
--- a/src/apps/ethereum/get_address.py
+++ b/src/apps/ethereum/get_address.py
@@ -37,7 +37,7 @@ def _ethereum_address_hex(address, network=None):
 
     hx = hexlify(address).decode()
 
-    prefix = str(network.chain_id) + '|' if rskip60 else ''
+    prefix = str(network.chain_id) + '0x' if rskip60 else ''
     hs = sha3_256(prefix + hx).digest(True)
     h = ''
 

--- a/tests/test_apps.ethereum.get_address.py
+++ b/tests/test_apps.ethereum.get_address.py
@@ -26,16 +26,16 @@ class TestEthereumGetAddress(unittest.TestCase):
     def test_ethereum_address_hex_rskip60(self):
         # https://github.com/rsksmart/RSKIPs/blob/master/IPs/RSKIP60.md
         rskip60_chain_30 = [
-            '0x5AaEb6053f3e94C9B9A09f33669435e7Ef1BeaeD',
-            '0xFb6916095ca1dF60BB79Ce92cE3EA74C37C5D359',
-            '0xdbf03b407C01e7cd3CbEA99509D93F8Dddc8c6fB',
-            '0xD1220A0cF47C7B9bE7a2E6ba89F429762e7b9aDB'
+            '0x5aaEB6053f3e94c9b9a09f33669435E7ef1bEAeD',
+            '0xFb6916095cA1Df60bb79ce92cE3EA74c37c5d359',
+            '0xDBF03B407c01E7CD3cBea99509D93F8Dddc8C6FB',
+            '0xD1220A0Cf47c7B9BE7a2e6ba89F429762E7B9adB'
         ]
         rskip60_chain_31 = [
-            '0x5AAEb6053f3E94c9B9A09f33669435e7EF1BeaeD',
-            '0xfB6916095CA1Df60bb79ce92CE3Ea74c37C5D359',
-            '0xDBF03B407C01E7Cd3cBEa99509d93f8DddC8C6Fb',
-            '0xd1220a0cf47C7b9be7A2e6BA89f429762e7b9AdB'
+            '0x5aAeb6053F3e94c9b9A09F33669435E7EF1BEaEd',
+            '0xFb6916095CA1dF60bb79CE92ce3Ea74C37c5D359',
+            '0xdbF03B407C01E7cd3cbEa99509D93f8dDDc8C6fB',
+            '0xd1220a0CF47c7B9Be7A2E6Ba89f429762E7b9adB'
         ]
         n = NetworkInfo(chain_id=30, slip44=1, shortcut='T', name='T', rskip60=True)
         for s in rskip60_chain_30:


### PR DESCRIPTION
RSKIP-60 checksum separator has changed: '0x' instead of '|'

Reference: https://github.com/rsksmart/RSKIPs/blob/master/IPs/RSKIP60.md