### PR TITLE
embed/firmware: update linker to use firmware_extra section

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,9 @@ PRODTEST_START      = 0x08040000
 
 BOARDLOADER_MAXSIZE = 49152
 BOOTLOADER_MAXSIZE  = 131072
-FIRMWARE_MAXSIZE    = 786432
+FIRMWARE_P1_MAXSIZE = 786432
+FIRMWARE_P2_MAXSIZE = 917504
+FIRMWARE_MAXSIZE    = 1703936
 
 GITREV=$(shell git describe --always --dirty)
 CFLAGS += -DGITREV=$(GITREV)
@@ -187,6 +189,8 @@ bloaty: ## run bloaty size profiler
 sizecheck: ## check sizes of binary files
 	test $(BOARDLOADER_MAXSIZE) -ge $(shell wc -c < $(BOARDLOADER_BUILD_DIR)/boardloader.bin)
 	test $(BOOTLOADER_MAXSIZE) -ge $(shell wc -c < $(BOOTLOADER_BUILD_DIR)/bootloader.bin)
+	test $(FIRMWARE_P1_MAXSIZE) -ge $(shell wc -c < $(FIRMWARE_BUILD_DIR)/firmware.bin.p1)
+	test $(FIRMWARE_P2_MAXSIZE) -ge $(shell wc -c < $(FIRMWARE_BUILD_DIR)/firmware.bin.p2)
 	test $(FIRMWARE_MAXSIZE) -ge $(shell wc -c < $(FIRMWARE_BUILD_DIR)/firmware.bin)
 
 combine: ## combine boardloader + bootloader + prodtest into one combined image

--- a/SConscript.firmware
+++ b/SConscript.firmware
@@ -298,6 +298,7 @@ env = Environment(ENV=os.environ, CFLAGS='%s -DPRODUCTION=%s -DPYOPT=%s' % (ARGU
 env.Tool('micropython')
 
 env.Replace(
+    CAT='cat',
     SED='sed',
     AS='arm-none-eabi-as',
     AR='arm-none-eabi-ar',
@@ -424,7 +425,9 @@ program_bin = env.Command(
     target='firmware.bin',
     source=program_elf,
     action=[
-        '$OBJCOPY -O binary -j .vendorheader -j .header -j .flash -j .data $SOURCE $TARGET',
+        '$OBJCOPY -O binary -j .vendorheader -j .header -j .flash -j .data --pad-to 0x08100000 $SOURCE ${TARGET}.p1',
+        '$OBJCOPY -O binary -j .flash2 $SOURCE ${TARGET}.p2',
+        '$CAT ${TARGET}.p1 ${TARGET}.p2 > $TARGET',
         '$BINCTL $TARGET -h',
         '$BINCTL $TARGET -s 1:2 `$KEYCTL sign firmware $TARGET 4747474747474747474747474747474747474747474747474747474747474747 4848484848484848484848484848484848484848484848484848484848484848`' if ARGUMENTS.get('PRODUCTION', '0') == '0' else '',
     ], )

--- a/embed/firmware/memory.ld
+++ b/embed/firmware/memory.ld
@@ -4,6 +4,7 @@ ENTRY(reset_handler)
 
 MEMORY {
   FLASH  (rx)  : ORIGIN = 0x08040000, LENGTH = 768K
+  FLASH2 (r)   : ORIGIN = 0x08120000, LENGTH = 896K
   CCMRAM (wal) : ORIGIN = 0x10000000, LENGTH = 64K
   SRAM   (wal) : ORIGIN = 0x20000000, LENGTH = 192K
 }
@@ -26,7 +27,7 @@ sram_end = ORIGIN(SRAM) + LENGTH(SRAM);
 _ram_start = sram_start;
 _ram_end = sram_end;
 
-_codelen = SIZEOF(.flash) + SIZEOF(.data);
+_codelen = LENGTH(FLASH) - SIZEOF(.vendorheader) - SIZEOF(.header) + SIZEOF(.flash2);
 _flash_start = ORIGIN(FLASH);
 _flash_end = ORIGIN(FLASH) + LENGTH(FLASH);
 _heap_start = ADDR(.heap);
@@ -40,6 +41,11 @@ SECTIONS {
   .header : ALIGN(4) {
     KEEP(*(.header));
   } >FLASH AT>FLASH
+
+  .flash2 : ALIGN(512) {
+    build/firmware/frozen_mpy.o(.rodata*);
+    . = ALIGN(512);
+  } >FLASH2 AT>FLASH2
 
   .flash : ALIGN(512) {
     KEEP(*(.vector_table));


### PR DESCRIPTION
These changes modify the linker script to utilize also the [firmware extra](https://github.com/trezor/trezor-core/blob/master/docs/memory.md) flash area as well. Currently, the MicroPython bytecode (`frozen_mpy.o`) is moved there (around 300K).

Old layout used almost full 768K in the firmware section and nothing was used in the firmware extra section (out of 896K) (i.e. 100% and 0%).

After the change the firmware section usage is around 470K and the firmware extra section usage is around 300K (i.e. 60% and  33%).

The resulting firmware is slightly bigger (because we need to pad the first section with zeroes) totalling at around 1070K (instead of the original 770K), but this provides space for future updates.