### PR TITLE
signtx layout: check if address starts with prefix

### DIFF
--- a/src/apps/wallet/sign_tx/layout.py
+++ b/src/apps/wallet/sign_tx/layout.py
@@ -29,7 +29,7 @@ async def confirm_output(ctx, output, coin):
                        ui.MONO, *split_op_return(data), icon_color=ui.GREEN)
     else:
         address = output.address
-        address_short = address[len(coin.cashaddr_prefix) + 1:] if coin.cashaddr_prefix is not None else address
+        address_short = address[len(coin.cashaddr_prefix) + 1:] if coin.cashaddr_prefix is not None and address.startswith(coin.cashaddr_prefix + ':') else address
         content = Text('Confirm sending', ui.ICON_SEND,
                        ui.NORMAL, format_coin_amount(output.amount, coin) + ' to',
                        ui.MONO, *split_address(address_short), icon_color=ui.GREEN)


### PR DESCRIPTION
Only addresses starting with bitcoincash: should get their prefix
skipped. This fixes a bug where it skips the first bytes of legacy
addresses.