### PR TITLE
openocd: separate stlink configs deprecated - now combined

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,7 @@ CROSS_PORT_OPTS ?=
 
 PRODUCTION ?= 0
 
-STLINK_VER ?= v2
-OPENOCD = openocd -f interface/stlink-$(STLINK_VER).cfg -c "transport select hla_swd" -f target/stm32f4x.cfg
+OPENOCD = openocd -f interface/stlink.cfg -c "transport select hla_swd" -f target/stm32f4x.cfg
 
 BOARDLOADER_START   = 0x08000000
 BOOTLOADER_START    = 0x08020000

--- a/docs/build.md
+++ b/docs/build.md
@@ -95,6 +95,5 @@ Use `make upload` to upload the firmware to a production device (with a bootload
 
 ### Flashing
 
-For flashing firmware to blank device (without bootloader) use `make flash`,
-or `make flash STLINK_VER=v2-1` if using a ST-LINK/V2.1 interface.
+For flashing firmware to blank device (without bootloader) use `make flash`.
 You need to have OpenOCD installed.


### PR DESCRIPTION
I noticed while running the latest commit of openocd (4999c9d98013eeb9746082f6b018e4b763ae3d37) the line:
`WARNING: interface/stlink-v2-1.cfg is deprecated, please switch to interface/stlink.cfg`

That file supposedly handles `STMicroelectronics ST-LINK/V1, ST-LINK/V2, ST-LINK/V2-1` now.
The commit message for that file says: `Extend HLA interface to allow multiple VID/PID pairs and use it to autodetect the connected stlink version.`

It seems to work with my dev kit (0483:374b STMicroelectronics ST-LINK/V2.1) and demo board (0483:3748 STMicroelectronics ST-LINK/V2) for erasing flash, re-flashing, and debugging - basically everything.

If it works for the openocd version that other developers are using please merge this. Thanks!