### PR TITLE
firmware: update flash_firmware target to use two-part flashing fix

### DIFF
--- a/SConscript.firmware
+++ b/SConscript.firmware
@@ -299,6 +299,7 @@ env.Tool('micropython')
 
 env.Replace(
     CAT='cat',
+    DD='dd',
     SED='sed',
     AS='arm-none-eabi-as',
     AR='arm-none-eabi-ar',
@@ -430,4 +431,5 @@ program_bin = env.Command(
         '$CAT ${TARGET}.p1 ${TARGET}.p2 > $TARGET',
         '$BINCTL $TARGET -h',
         '$BINCTL $TARGET -s 1:2 `$KEYCTL sign firmware $TARGET 4747474747474747474747474747474747474747474747474747474747474747 4848484848484848484848484848484848484848484848484848484848484848`' if ARGUMENTS.get('PRODUCTION', '0') == '0' else '',
+        '$DD if=$TARGET of=${TARGET}.p1 skip=0 bs=128K count=6',
     ], )


### PR DESCRIPTION
binctl changes firmware.bin after it's put together from p1 and p2. so just need to copy back out p1 from firmware.bin.