### PR TITLE
build: make it easier to build binaries optimized for debugging

### DIFF
--- a/SConscript.boardloader
+++ b/SConscript.boardloader
@@ -99,7 +99,7 @@ env.Replace(
     OBJCOPY='arm-none-eabi-objcopy', )
 
 env.Replace(
-    CCFLAGS='-Os '
+    CCFLAGS=env.get('ENV').get('OPTIMIZE', '-Os') + ' '
     '-g3 '
     '-nostdlib '
     '-std=gnu99 -Wall -Werror -Wdouble-promotion -Wpointer-arith -fno-common '

--- a/SConscript.bootloader
+++ b/SConscript.bootloader
@@ -120,7 +120,7 @@ env.Replace(
     OBJCOPY='arm-none-eabi-objcopy', )
 
 env.Replace(
-    CCFLAGS='-Os '
+    CCFLAGS=env.get('ENV').get('OPTIMIZE', '-Os') + ' '
     '-g3 '
     '-nostdlib '
     '-std=gnu99 -Wall -Werror -Wdouble-promotion -Wpointer-arith -fno-common '

--- a/SConscript.firmware
+++ b/SConscript.firmware
@@ -310,7 +310,7 @@ env.Replace(
     OBJCOPY='arm-none-eabi-objcopy', )
 
 env.Replace(
-    COPT='-Os',
+    COPT=env.get('ENV').get('OPTIMIZE', '-Os'),
     CCFLAGS='$COPT '
     '-g3 '
     '-nostdlib '

--- a/SConscript.prodtest
+++ b/SConscript.prodtest
@@ -89,7 +89,7 @@ env.Replace(
     OBJCOPY='arm-none-eabi-objcopy', )
 
 env.Replace(
-    CCFLAGS='-Os '
+    CCFLAGS=env.get('ENV').get('OPTIMIZE', '-Os') + ' '
     '-g3 '
     '-nostdlib '
     '-std=gnu99 -Wall -Werror -Wdouble-promotion -Wpointer-arith -fno-common '

--- a/SConscript.reflash
+++ b/SConscript.reflash
@@ -89,7 +89,7 @@ env.Replace(
     OBJCOPY='arm-none-eabi-objcopy', )
 
 env.Replace(
-    CCFLAGS='-Os '
+    CCFLAGS=env.get('ENV').get('OPTIMIZE', '-Os') + ' '
     '-g3 '
     '-nostdlib '
     '-std=gnu99 -Wall -Werror -Wdouble-promotion -Wpointer-arith -fno-common '


### PR DESCRIPTION
this is just a little development aid so that i don't have to keep patching the scons files to build binaries that are not optimized for size. the size optimized binaries are a pain to debug because the optimizations cause a lot of jumping around in the source.

example dev kit usage with this patch applied:
`pipenv run make clean vendor build_boardloader build_bootloader build_firmware flash openocd_reset DISPLAY_ILI9341V=1 STLINK_VER=v2-1 OPTIMIZE=-Og`

simply leave off the OPTIMIZE variable to get default current behavior.