### PR TITLE
build: update to use latest arm none eabi toolchain gcc-arm-none-eabi-7-2018-q2-update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
   global:
     - PROTOBUF_VERSION=3.4.0
   matrix:
-    - GOAL=stm32 TOOLCHAIN_SHORTVER=7-2017q4 TOOLCHAIN_LONGVER=gcc-arm-none-eabi-7-2017-q4-major
+    - GOAL=stm32 TOOLCHAIN_SHORTVER=7-2018q2 TOOLCHAIN_LONGVER=gcc-arm-none-eabi-7-2018-q2-update
     - GOAL=unix
     - GOAL=src
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,8 @@ RUN apt-get update && apt-get install -y \
 
 # download toolchain
 
-ENV TOOLCHAIN_SHORTVER=7-2017q4
-ENV TOOLCHAIN_LONGVER=gcc-arm-none-eabi-7-2017-q4-major
+ENV TOOLCHAIN_SHORTVER=7-2018q2
+ENV TOOLCHAIN_LONGVER=gcc-arm-none-eabi-7-2018-q2-update
 ENV TOOLCHAIN_FLAVOR=linux
 ENV TOOLCHAIN_URL=https://developer.arm.com/-/media/Files/downloads/gnu-rm/$TOOLCHAIN_SHORTVER/$TOOLCHAIN_LONGVER-$TOOLCHAIN_FLAVOR.tar.bz2
 

--- a/Dockerfile.gcc_source
+++ b/Dockerfile.gcc_source
@@ -11,8 +11,8 @@ RUN apt-get update && apt-get install -y \
 
 # download toolchain
 
-ENV TOOLCHAIN_SHORTVER=7-2017q4
-ENV TOOLCHAIN_LONGVER=gcc-arm-none-eabi-7-2017-q4-major
+ENV TOOLCHAIN_SHORTVER=7-2018q2
+ENV TOOLCHAIN_LONGVER=gcc-arm-none-eabi-7-2018-q2-update
 ENV TOOLCHAIN_FLAVOR=src
 ENV TOOLCHAIN_URL=https://developer.arm.com/-/media/Files/downloads/gnu-rm/$TOOLCHAIN_SHORTVER/$TOOLCHAIN_LONGVER-$TOOLCHAIN_FLAVOR.tar.bz2
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -76,7 +76,7 @@ sudo apt-get install scons gcc-arm-none-eabi libnewlib-arm-none-eabi
 
 #### OS X
 
-1. Download [gcc-arm-none-eabi](https://launchpad.net/gcc-arm-embedded/5.0/5-2016-q3-update/)
+1. Download [gcc-arm-none-eabi](https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads)
 2. Follow the [install instructions](https://launchpadlibrarian.net/287100883/readme.txt)
 3. To install OpenOCD, run `brew install open-ocd`
 4. Run `make vendor build_boardloader build_bootloader build_firmware`


### PR DESCRIPTION
There is an updated gcc-arm-none-eabi-7-2018-q2-update toolchain available at https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads. They fixed the GDB TUI so it works again in this release (aids working in the debugger).

Things seem to work for building and debugging without any grief. I didn't see any extra built time warning messages either. I did NOT diff the binaries before and after (might later). Here's what I have verified works:

tested dev kit:
- `pipenv run make clean vendor build_boardloader build_bootloader build_firmware flash openocd_reset DISPLAY_ILI9341V=1 STLINK_VER=v2-1 OPTIMIZE=-Og`
- `make openocd STLINK_VER=v2-1`
- `make gdb_boardloader`

tested prototype hardware:
- `pipenv run make clean vendor build_boardloader build_bootloader build_firmware flash openocd_reset OPTIMIZE=-Og`
- `make openocd`
- `make gdb_boardloader`