### PR TITLE
boardloader: partial fix for powering off sd card

### DIFF
--- a/embed/trezorhal/sdcard.c
+++ b/embed/trezorhal/sdcard.c
@@ -115,7 +115,7 @@ secbool sdcard_power_on(void) {
     HAL_Delay(50);
 
     if (sectrue != sdcard_is_present()) {
-        return secfalse;
+        goto error;
     }
     if (sd_handle.Instance) {
         return sectrue;
@@ -147,17 +147,15 @@ secbool sdcard_power_on(void) {
     return sectrue;
 
 error:
-    sd_handle.Instance = NULL;
+    sdcard_power_off();
     return secfalse;
 }
 
 void sdcard_power_off(void) {
-    if (NULL == sd_handle.Instance) {
-        return;
+    if (sd_handle.Instance != NULL) {
+        HAL_SD_DeInit(&sd_handle);
+        sd_handle.Instance = NULL;
     }
-    HAL_SD_DeInit(&sd_handle);
-    sd_handle.Instance = NULL;
-
     // turn off SD card circuitry
     HAL_Delay(50);
     sdcard_default_pin_state();


### PR DESCRIPTION
Referencing https://github.com/trezor/trezor-core/issues/183 and https://github.com/trezor/trezor-core/issues/86

I was testing with the new prototype board and found this bug.
Running build of current master: `pipenv run make clean vendor build_boardloader build_bootloader build_firmware flash openocd_reset OPTIMIZE=-Og`

I found this bug by starting up with the sd card inserted.
During 10 second countdown eject sd the card (or rapidly eject and re-insert -- it's a race condition).

You'll get a red screen fatal error, like:
```
expr: sdcard_power_on()
file: embed/boardloader/main.c:52
func: check_sdcard
rev: 95416629
```

Re-insert the sd card and the system resets.

I think this bug shows that the problem of in-rush current causing a power fault while inserting a micro sd card while the sd power is on is still not entirely solved.

Maybe the circuitry should only allow the MOSFET to turn on if the gate is low AND the SD card detect (debounced) is low?

To simulate the race in the debugger:
- plug in debug adapter
- plug in prototype board
- make openocd
- make gdb_boardloader
- insert bootloader formatted micro sdcard
```
(gdb) b *copy_sdcard
(gdb) c
(gdb) b *sdcard_power_on
(gdb) c
(gdb) b *sdcard_is_present
(gdb) c
(gdb) lay src
(gdb) bt (note that the micro sdcard is powered on at this point)
#0  sdcard_is_present () at embed/trezorhal/sdcard.c:108
#1  0x08009162 in sdcard_power_on () at embed/trezorhal/sdcard.c:117
#2  0x08005c04 in check_sdcard () at embed/boardloader/main.c:52
#3  0x08005d0e in copy_sdcard () at embed/boardloader/main.c:97
#4  0x08005ece in main () at embed/boardloader/main.c:187
```
- eject sd card
- `(gdb) c`
- get the fatal error screen
- insert card and get system reset

This PR fixes this particular bug. With it, the system will not reset because the SD power switch is turned off. But, it does not fix for other similar cases, like ejecting the sd card in the middle of the boardloader's copying of the bootloader from the sdcard like at line `ensure(sdcard_read_blocks(buf, i, 1), NULL);`
That's why I wonder if the circuitry needs to be AND'ed with the card detect circuit.