### PR TITLE
extmod-sha3: keccak parameter in the constructor

### DIFF
--- a/embed/extmod/modtrezorcrypto/modtrezorcrypto-sha3-256.h
+++ b/embed/extmod/modtrezorcrypto/modtrezorcrypto-sha3-256.h
@@ -29,22 +29,34 @@
 typedef struct _mp_obj_Sha3_256_t {
     mp_obj_base_t base;
     SHA3_CTX ctx;
+    int keccak;
 } mp_obj_Sha3_256_t;
 
 STATIC mp_obj_t mod_trezorcrypto_Sha3_256_update(mp_obj_t self, mp_obj_t data);
 
-/// def __init__(self, data: bytes = None) -> None:
+/// def __init__(self, data: bytes = None, keccak = False) -> None:
 ///     '''
 ///     Creates a hash context object.
 ///     '''
 STATIC mp_obj_t mod_trezorcrypto_Sha3_256_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
-    mp_arg_check_num(n_args, n_kw, 0, 1, false);
+    mp_arg_check_num(n_args, n_kw, 0, 1, true);
     mp_obj_Sha3_256_t *o = m_new_obj(mp_obj_Sha3_256_t);
     o->base.type = type;
+    o->keccak = 0;
     sha3_256_Init(&(o->ctx));
-    // constructor called with bytes/str as first parameter
-    if (n_args == 1) {
-        mod_trezorcrypto_Sha3_256_update(MP_OBJ_FROM_PTR(o), args[0]);
+
+    STATIC const mp_arg_t allowed_args[] = {
+        { MP_QSTR_data,    MP_ARG_OBJ,                   {.u_obj = mp_const_none} },
+        { MP_QSTR_keccak,  MP_ARG_OBJ | MP_ARG_KW_ONLY,  {.u_obj = MP_OBJ_NULL} },
+    };
+    mp_arg_val_t vals[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all_kw_array(n_args, n_kw, args, MP_ARRAY_SIZE(allowed_args), allowed_args, vals);
+    if (vals[1].u_obj != MP_OBJ_NULL){
+        o->keccak = mp_obj_is_true(vals[1].u_obj) ? 1 : -1;
+    }
+
+    if (vals[0].u_obj != mp_const_none){
+        mod_trezorcrypto_Sha3_256_update(MP_OBJ_FROM_PTR(o), vals[0].u_obj);
     }
     return MP_OBJ_FROM_PTR(o);
 }
@@ -72,8 +84,9 @@ STATIC mp_obj_t mod_trezorcrypto_Sha3_256_digest(size_t n_args, const mp_obj_t *
     mp_obj_Sha3_256_t *o = MP_OBJ_TO_PTR(args[0]);
     uint8_t out[SHA3_256_DIGEST_LENGTH];
     SHA3_CTX ctx;
+    bool use_keccak = n_args > 1 ? args[1] == mp_const_true : o->keccak == 1;
     memcpy(&ctx, &(o->ctx), sizeof(SHA3_CTX));
-    if (n_args > 1 && args[1] == mp_const_true) {
+    if (use_keccak) {
         keccak_Final(&ctx, out);
     } else {
         sha3_Final(&ctx, out);
@@ -82,6 +95,20 @@ STATIC mp_obj_t mod_trezorcrypto_Sha3_256_digest(size_t n_args, const mp_obj_t *
     return mp_obj_new_bytes(out, sizeof(out));
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(mod_trezorcrypto_Sha3_256_digest_obj, 1, 2, mod_trezorcrypto_Sha3_256_digest);
+
+/// def copy(self) -> sha3:
+///     '''
+///     Returns the copy of the digest object with the current state
+///     '''
+STATIC mp_obj_t mod_trezorcrypto_Sha3_256_copy(size_t n_args, const mp_obj_t *args) {
+    mp_obj_Sha3_256_t *o = MP_OBJ_TO_PTR(args[0]);
+    mp_obj_Sha3_256_t *out = m_new_obj(mp_obj_Sha3_256_t);
+    out->base.type = o->base.type;
+    out->keccak = o->keccak;
+    memcpy(&(out->ctx), &(o->ctx), sizeof(SHA3_CTX));
+    return MP_OBJ_FROM_PTR(out);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(mod_trezorcrypto_Sha3_256_copy_obj, 1, 1, mod_trezorcrypto_Sha3_256_copy);
 
 STATIC mp_obj_t mod_trezorcrypto_Sha3_256___del__(mp_obj_t self) {
     mp_obj_Sha3_256_t *o = MP_OBJ_TO_PTR(self);
@@ -93,6 +120,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(mod_trezorcrypto_Sha3_256___del___obj, mod_trez
 STATIC const mp_rom_map_elem_t mod_trezorcrypto_Sha3_256_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_update), MP_ROM_PTR(&mod_trezorcrypto_Sha3_256_update_obj) },
     { MP_ROM_QSTR(MP_QSTR_digest), MP_ROM_PTR(&mod_trezorcrypto_Sha3_256_digest_obj) },
+    { MP_ROM_QSTR(MP_QSTR_copy), MP_ROM_PTR(&mod_trezorcrypto_Sha3_256_copy_obj) },
     { MP_ROM_QSTR(MP_QSTR___del__), MP_ROM_PTR(&mod_trezorcrypto_Sha3_256___del___obj) },
     { MP_ROM_QSTR(MP_QSTR_block_size), MP_OBJ_NEW_SMALL_INT(SHA3_256_BLOCK_LENGTH) },
     { MP_ROM_QSTR(MP_QSTR_digest_size), MP_OBJ_NEW_SMALL_INT(SHA3_256_DIGEST_LENGTH) },


### PR DESCRIPTION
Enables to construct keccak-sha3 so the Digest object can be used in hmac / pbkdf transparently (without need to call special digest(keccak=True) as some functions taking Digest object call digest() directly so keccak mode have to be specified before that point)