### PR TITLE
boardloader, sdcard: avoid fatal error when card is ejected during countdown

### DIFF
--- a/embed/boardloader/main.c
+++ b/embed/boardloader/main.c
@@ -45,11 +45,9 @@ static const uint8_t * const BOARDLOADER_KEYS[] = {
 
 static uint32_t check_sdcard(void)
 {
-    if (sectrue != sdcard_is_present()) {
+    if (sectrue != sdcard_power_on()) {
         return 0;
     }
-
-    ensure(sdcard_power_on(), NULL);
 
     uint64_t cap = sdcard_get_capacity_in_bytes();
     if (cap < 1024 * 1024) {


### PR DESCRIPTION
during the 10 second countdown, there is a race between the `sdcard_is_present` check and the `sdcard_is_present` check just within the `sdcard_power_on`.
if you pass the first and fail the second by ejecting at just the right time, you get a message like:
```
FATAL ERROR:
expr: sdcard_power_on()
file: embed/boardloader/main.c:52
func: check_sdcard
```

instead of `no SD card, aborting`

this fixes:
https://github.com/trezor/trezor-core/pull/279#issuecomment-407058722

the way to reproduce the condition with the debugger is much the same process as documented at https://github.com/trezor/trezor-core/pull/279#issue-201478305
