### PR TITLE
src/apps/ethereum: support full 32bit chain_id

### DIFF
--- a/src/apps/ethereum/sign_tx.py
+++ b/src/apps/ethereum/sign_tx.py
@@ -138,7 +138,9 @@ async def send_signature(ctx, msg: EthereumSignTx, digest):
 
     req = EthereumTxRequest()
     req.signature_v = signature[0]
-    if msg.chain_id:
+    if msg.chain_id > MAX_CHAIN_ID:
+        req.signature_v -= 27
+    elif msg.chain_id:
         req.signature_v += 2 * msg.chain_id + 8
 
     req.signature_r = signature[1:33]
@@ -151,7 +153,7 @@ def check(msg: EthereumSignTx):
     if msg.tx_type not in [1, 6, None]:
         raise wire.DataError("tx_type out of bounds")
 
-    if msg.chain_id < 0 or msg.chain_id > MAX_CHAIN_ID:
+    if msg.chain_id < 0:
         raise wire.DataError("chain_id out of bounds")
 
     if msg.data_length > 0:


### PR DESCRIPTION
 * remove chain_id restriction to support full 32bit chain_id.
 * for chain_id > MAX_CHAIN_ID(2147483630) case, simply return v signature parity.
 * see also https://github.com/trezor/trezor-mcu/pull/399