### PR TITLE
docker: protobuf stuff added

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,9 +22,13 @@ RUN cd /opt && wget $TOOLCHAIN_URL && tar xfj $TOOLCHAIN_LONGVER-$TOOLCHAIN_FLAV
 
 ENV PATH=/opt/$TOOLCHAIN_LONGVER/bin:$PATH
 
+# install additional tools
+
+RUN apt-get install -y protobuf-compiler libprotobuf-dev
+
 # install python tools
 
-RUN pip3 install click pyblake2 scons
+RUN pip3 install click pyblake2 scons protobuf
 RUN pip3 install --no-deps git+https://github.com/trezor/python-trezor.git@master
 
 # workarounds for weird default install


### PR DESCRIPTION
Im not sure why, but anyway I can build with this fix

~~~sh
$ sh build-docker.sh
....
  * fngprnt : 9fc8eb527f6563b283ce2f52f53bb47f4cfb6f6a7f8f76e0d951e107979ba520

dd if=build/firmware/firmware.bin of=build/firmware/firmware.bin.p1 skip=0 bs=128k count=6
6+0 records in
6+0 records out
786432 bytes (786 kB, 768 KiB) copied, 0.000696389 s, 1.1 GB/s
$
~~~
