### PR TITLE
lisk: fix raw transaction fields update

### DIFF
--- a/src/apps/lisk/sign_tx.py
+++ b/src/apps/lisk/sign_tx.py
@@ -47,7 +47,9 @@ async def _get_keys(ctx, msg):
 
 
 def _update_raw_tx(transaction, pubkey):
-    transaction.sender_public_key = pubkey
+    # If device is using for second signature sender_public_key must be exist in transaction
+    if not transaction.sender_public_key:
+        transaction.sender_public_key = pubkey
 
     # For CastVotes transactions, recipientId should be equal to transaction
     # creator address.


### PR DESCRIPTION
If a device is using for second signature calculation `sender_public_key` field must exist in a Lisk transaction message and not be replaced by the device public key. 

https://github.com/trezor/trezor-mcu/pull/351 updated with the right logic too. 