### PR TITLE
workflow: allow more arguments to the import workflow

### DIFF
--- a/src/trezor/wire/__init__.py
+++ b/src/trezor/wire/__init__.py
@@ -165,11 +165,11 @@ async def protobuf_workflow(ctx, reader, handler, *args):
         await ctx.write(res)
 
 
-def import_workflow(ctx, req, pkgname, modname):
+def import_workflow(ctx, req, pkgname, modname, *args):
     modpath = "%s.%s" % (pkgname, modname)
     module = __import__(modpath, None, None, (modname,), 0)
     handler = getattr(module, modname)
-    return handler(ctx, req)
+    return handler(ctx, req, *args)
 
 
 async def unexpected_msg(ctx, reader):


### PR DESCRIPTION
Allows to use stateful message handlers

```python
wire.add(MessageType.MoneroTransactionSign, __name__, "get_address", STATE)
```