### PR TITLE
lisk: fix _update_raw_tx function for second signature calculation

### DIFF
--- a/src/apps/lisk/sign_tx.py
+++ b/src/apps/lisk/sign_tx.py
@@ -54,7 +54,8 @@ def _update_raw_tx(transaction, pubkey):
     # For CastVotes transactions, recipientId should be equal to transaction
     # creator address.
     if transaction.type == LiskTransactionType.CastVotes:
-        transaction.recipient_id = get_address_from_public_key(pubkey)
+        if not transaction.recipient_id:
+            transaction.recipient_id = get_address_from_public_key(pubkey)
 
     return transaction
 


### PR DESCRIPTION
This pr provides additional fixes for the previous PR https://github.com/trezor/trezor-core/pull/322
Transaction fields `sender_public_key` and `recipient_id` should be created by a device if they are not provided. 

`trezor-mcu` pr for lisk integration also updated https://github.com/trezor/trezor-mcu/pull/351/commits/34048367158d08c9a7b4e84f49656d4a7ec7c1bc