### PR TITLE
Stellar: explicitly specifying native asset in payment op causes "firmware error"

### DIFF
--- a/src/apps/stellar/operations/serialize.py
+++ b/src/apps/stellar/operations/serialize.py
@@ -158,7 +158,7 @@ def _write_asset_code(w, asset_type: int, asset_code: str):
 
 
 def _write_asset(w, asset: StellarAssetType):
-    if asset is None:
+    if asset is None or asset.type == consts.ASSET_TYPE_NATIVE:
         writers.write_uint32(w, 0)
         return
     writers.write_uint32(w, asset.type)


### PR DESCRIPTION
A payment op that uses the native asset will have an asset of type 0 and no other fields populated.

This gets parsed into a protobuf message like:

```
StellarPaymentOp (67 bytes) {
    amount: 10000000,
    asset: StellarAssetType (2 bytes) {
        type: 0,
    },
    destination_account: '<redacted>',
}
```

This shows up in python as an asset with a `type` but without a `code` or `issuer`. Since the asset is non-null, the code in `_write_asset` attempts to read `asset.code` and fails.

You can reproduce this by running the following command against the Model T emulator:

```
trezorctl -v stellar_sign_transaction -n "Test SDF Network ; September 2015" AAAAABXWSL/k028ZbPtXNf/YylTNS4Iz90PyJEnefPMBzbRpAAAAZAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAEAAAAAdV71t94srF0FKF9TmMK7sgQXPj9XH+Ma8Mv213jtSksAAAAAAAAAAACYloAAAAAAAAAAAA==
```

### Adding a test?

I tried to add a test for this to the trezor-python repo but when I ran the test suite and it tried to load the mnemonic I got the following error:

```
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
trezorlib/tests/device_tests/common.py:72: in setup_mnemonic_nopin_nopassphrase
    self._setup_mnemonic()
trezorlib/tests/device_tests/common.py:65: in _setup_mnemonic
    language="english",
trezorlib/tools.py:192: in wrapped_f
    ret = f(*args, **kwargs)
trezorlib/debuglink.py:186: in load_device_by_mnemonic
    skip_checksum=skip_checksum,
trezorlib/client.py:148: in call
    msg = handler(resp)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <trezorlib.client.TrezorClientDebugLink object at 0x7f0a84bcd2b0>
msg = <Failure: {'code': 1, 'message': 'Unexpected message'}>

    def callback_Failure(self, msg):
        if msg.code in (
            proto.FailureType.PinInvalid,
            proto.FailureType.PinCancelled,
            proto.FailureType.PinExpected,
        ):
            raise PinException(msg.code, msg.message)
    
>       raise tools.CallException(msg.code, msg.message)
E       trezorlib.tools.CallException: (1, 'Unexpected message')

trezorlib/client.py:165: CallException
--------------------------------------- Captured stdout setup ----------------------------------------
Pressing True
User pressed "y"
```

I'm also unable to load the mnemonic from the command line into the Model T emulator (I get the same "unexpected message" error). Is there a workaround or would you like me to log a separate issue?