### PR TITLE
tools/build_mocks fix

### DIFF
--- a/tools/build_mocks
+++ b/tools/build_mocks
@@ -83,7 +83,7 @@ def build_module(mod_file, dest):
 
 def build_directory(dir, dest):
     print("Building mocks for", dir, "to", dest)
-    for pkg in sorted(os.listdir(dir)):
+    for pkg in sorted([x for x in os.listdir(dir) if os.path.isdir(os.path.join(dir, x))]):
         for mod in sorted(os.listdir(os.path.join(dir, pkg))):
             build_module(os.path.join(dir, pkg, mod), dest)
 


### PR DESCRIPTION
Fixes

```
uilding mocks for ../embed/extmod to ../mocks/generated
Traceback (most recent call last):
  File "./build_mocks", line 112, in <module>
    build_directory("../embed/extmod", "../mocks/generated")
  File "./build_mocks", line 87, in build_directory
    for mod in sorted(os.listdir(os.path.join(dir, pkg))):
NotADirectoryError: [Errno 20] Not a directory: '../embed/extmod/trezorobj.h'
```