### PR TITLE
decred: add initial support

### DIFF
--- a/src/apps/common/coininfo.py
+++ b/src/apps/common/coininfo.py
@@ -1,6 +1,6 @@
 # generated from coininfo.py.mako
 # do not edit manually!
-from trezor.crypto.base58 import groestl512d_32, sha256d_32
+from trezor.crypto.base58 import blake256_32, groestl512d_32, sha256d_32
 
 
 class CoinInfo:
@@ -47,6 +47,9 @@ class CoinInfo:
         self.curve_name = curve_name
         if curve_name == "secp256k1-groestl":
             self.b58_hash = groestl512d_32
+            self.sign_hash_double = False
+        elif curve_name == "secp256k1-decred":
+            self.b58_hash = blake256_32
             self.sign_hash_double = False
         else:
             self.b58_hash = sha256d_32

--- a/src/apps/common/coininfo.py.mako
+++ b/src/apps/common/coininfo.py.mako
@@ -1,6 +1,6 @@
 # generated from coininfo.py.mako
 # do not edit manually!
-from trezor.crypto.base58 import groestl512d_32, sha256d_32
+from trezor.crypto.base58 import blake256_32, groestl512d_32, sha256d_32
 
 
 class CoinInfo:
@@ -47,6 +47,9 @@ class CoinInfo:
         self.curve_name = curve_name
         if curve_name == "secp256k1-groestl":
             self.b58_hash = groestl512d_32
+            self.sign_hash_double = False
+        elif curve_name == "secp256k1-decred":
+            self.b58_hash = blake256_32
             self.sign_hash_double = False
         else:
             self.b58_hash = sha256d_32

--- a/src/apps/common/signverify.py
+++ b/src/apps/common/signverify.py
@@ -1,13 +1,16 @@
 from ubinascii import hexlify
 
-from trezor.crypto.hashlib import sha256
+from trezor.crypto.hashlib import blake256, sha256
 from trezor.utils import HashWriter
 
 from apps.wallet.sign_tx.signing import write_varint
 
 
 def message_digest(coin, message):
-    h = HashWriter(sha256)
+    if coin.decred:
+        h = HashWriter(blake256)
+    else:
+        h = HashWriter(sha256)
     write_varint(h, len(coin.signed_message_header))
     h.extend(coin.signed_message_header)
     write_varint(h, len(message))

--- a/src/apps/common/writers.py
+++ b/src/apps/common/writers.py
@@ -14,6 +14,13 @@ def write_uint8(w: bytearray, n: int) -> int:
     return 1
 
 
+def write_uint16_le(w: bytearray, n: int) -> int:
+    assert 0 <= n <= 0xFFFF
+    w.append(n & 0xFF)
+    w.append((n >> 8) & 0xFF)
+    return 2
+
+
 def write_uint32_le(w: bytearray, n: int) -> int:
     assert 0 <= n <= 0xFFFFFFFF
     w.append(n & 0xFF)

--- a/src/apps/wallet/sign_tx/decred_prefix_hasher.py
+++ b/src/apps/wallet/sign_tx/decred_prefix_hasher.py
@@ -1,0 +1,65 @@
+from micropython import const
+
+from trezor.crypto.hashlib import blake256
+from trezor.messages.SignTx import SignTx
+from trezor.messages.TxInputType import TxInputType
+from trezor.messages.TxOutputBinType import TxOutputBinType
+from trezor.utils import HashWriter
+
+from apps.wallet.sign_tx.writers import (
+    write_tx_input_decred,
+    write_tx_output,
+    write_uint32,
+    write_varint,
+)
+
+DECRED_SERIALIZE_FULL = const(0 << 16)
+DECRED_SERIALIZE_NO_WITNESS = const(1 << 16)
+DECRED_SERIALIZE_WITNESS_SIGNING = const(3 << 16)
+
+DECRED_SIGHASHALL = const(1)
+
+
+class DecredPrefixHasher:
+    """
+    While Decred does not have the exact same implementation as bip143/zip143,
+    the semantics for using the prefix hash of transactions are close enough
+    that a pseudo-bip143 class can be used to store the prefix hash during the
+    check_fee stage of transaction signature to then reuse it at the sign_tx
+    stage without having to request the inputs again.
+    """
+
+    def __init__(self, tx: SignTx):
+        self.h_prefix = HashWriter(blake256)
+        self.last_output_bytes = None
+        write_uint32(self.h_prefix, tx.version | DECRED_SERIALIZE_NO_WITNESS)
+        write_varint(self.h_prefix, tx.inputs_count)
+
+    def add_prevouts(self, txi: TxInputType):
+        write_tx_input_decred(self.h_prefix, txi)
+
+    def add_sequence(self, txi: TxInputType):
+        pass
+
+    def add_output_count(self, tx: SignTx):
+        write_varint(self.h_prefix, tx.outputs_count)
+
+    def add_output(self, txo_bin: TxOutputBinType):
+        write_tx_output(self.h_prefix, txo_bin)
+
+    def set_last_output_bytes(self, w_txo_bin: bytearray):
+        """
+        This is required because the last serialized output obtained in
+        `check_fee` will only be sent to the client in `sign_tx`
+        """
+        self.last_output_bytes = w_txo_bin
+
+    def get_last_output_bytes(self):
+        return self.last_output_bytes
+
+    def add_locktime_expiry(self, tx: SignTx):
+        write_uint32(self.h_prefix, tx.lock_time)
+        write_uint32(self.h_prefix, tx.expiry)
+
+    def prefix_hash(self) -> bytes:
+        return self.h_prefix.get_digest()

--- a/src/apps/wallet/sign_tx/scripts.py
+++ b/src/apps/wallet/sign_tx/scripts.py
@@ -1,6 +1,7 @@
-from trezor.crypto.hashlib import ripemd160, sha256
+from trezor.crypto.hashlib import blake256, ripemd160, sha256
 from trezor.messages.MultisigRedeemScriptType import MultisigRedeemScriptType
 
+from apps.common.coininfo import CoinInfo
 from apps.common.writers import empty_bytearray
 from apps.wallet.sign_tx.multisig import multisig_get_pubkeys
 from apps.wallet.sign_tx.writers import (
@@ -192,6 +193,7 @@ def input_script_multisig(
     signature: bytes,
     signature_index: int,
     sighash: int,
+    coin: CoinInfo,
 ):
     signatures = multisig.signatures  # other signatures
     if len(signatures[signature_index]) > 0:
@@ -199,10 +201,12 @@ def input_script_multisig(
     signatures[signature_index] = signature  # our signature
 
     w = bytearray()
-    # Starts with OP_FALSE because of an old OP_CHECKMULTISIG bug, which
-    # consumes one additional item on the stack:
-    # https://bitcoin.org/en/developer-guide#standard-transactions
-    w.append(0x00)
+
+    if not coin.decred:
+        # Starts with OP_FALSE because of an old OP_CHECKMULTISIG bug, which
+        # consumes one additional item on the stack:
+        # https://bitcoin.org/en/developer-guide#standard-transactions
+        w.append(0x00)
 
     for s in signatures:
         if len(s):
@@ -265,5 +269,11 @@ def append_pubkey(w: bytearray, pubkey: bytes) -> bytearray:
 
 def sha256_ripemd160_digest(b: bytes) -> bytes:
     h = sha256(b).digest()
+    h = ripemd160(h).digest()
+    return h
+
+
+def blake256_ripemd160_digest(b: bytes) -> bytes:
+    h = blake256(b).digest()
     h = ripemd160(h).digest()
     return h

--- a/src/apps/wallet/sign_tx/signing.py
+++ b/src/apps/wallet/sign_tx/signing.py
@@ -2,7 +2,7 @@ from micropython import const
 
 from trezor.crypto import base58, bip32, cashaddr, der
 from trezor.crypto.curve import secp256k1
-from trezor.crypto.hashlib import sha256
+from trezor.crypto.hashlib import blake256, sha256
 from trezor.messages import OutputScriptType
 from trezor.messages.TxRequestDetailsType import TxRequestDetailsType
 from trezor.messages.TxRequestSerializedType import TxRequestSerializedType
@@ -34,6 +34,11 @@ _BIP32_CHANGE_CHAIN = const(1)
 # the maximum allowed change address.  this should be large enough for normal
 # use and still allow to quickly brute-force the correct bip32 path
 _BIP32_MAX_LAST_ELEMENT = const(1000000)
+
+
+DECRED_SERIALIZE_FULL = const(0 << 16)
+DECRED_SERIALIZE_NO_WITNESS = const(1 << 16)
+DECRED_SERIALIZE_WITNESS_SIGNING = const(3 << 16)
 
 
 class SigningError(ValueError):
@@ -143,6 +148,14 @@ async def check_tx_fee(tx: SignTx, root: bip32.HDNode):
         elif not await confirm_output(txo, coin):
             raise SigningError(FailureType.ActionCancelled, "Output cancelled")
 
+        if coin.decred:
+            if txo.decred_script_version is not None and txo.decred_script_version != 0:
+                raise SigningError(
+                    FailureType.ActionCancelled,
+                    "Cannot send to output with script version != 0",
+                )
+            txo_bin.decred_script_version = txo.decred_script_version
+
         write_tx_output(h_first, txo_bin)
         hash143.add_output(txo_bin)
         total_out += txo_bin.amount
@@ -182,6 +195,19 @@ async def sign_tx(tx: SignTx, root: bip32.HDNode):
     tx_req = TxRequest()
     tx_req.details = TxRequestDetailsType()
     tx_req.serialized = None
+
+    h_prefix_sign = None
+    if coin.decred:
+        h_prefix_sign = HashWriter(blake256)
+
+        # used to validate no changes between check_tx_fee and phase 2
+        h_second = HashWriter(sha256)
+
+        # used to validate no changes between phase 2 and decred witness
+        h_third = HashWriter(sha256)
+        h_fourth = HashWriter(sha256)
+        write_uint32(h_prefix_sign, tx.version | DECRED_SERIALIZE_NO_WITNESS)
+        write_varint(h_prefix_sign, tx.inputs_count)
 
     for i_sign in range(tx.inputs_count):
         progress.advance()
@@ -234,7 +260,11 @@ async def sign_tx(tx: SignTx, root: bip32.HDNode):
             key_sign = node_derive(root, txi_sign.address_n)
             key_sign_pub = key_sign.public_key()
             hash143_hash = hash143.preimage_hash(
-                coin, tx, txi_sign, ecdsa_hash_pubkey(key_sign_pub), get_hash_type(coin)
+                coin,
+                tx,
+                txi_sign,
+                ecdsa_hash_pubkey(key_sign_pub, coin),
+                get_hash_type(coin),
             )
 
             # if multisig, check if singing with a key that is included in multisig
@@ -258,6 +288,22 @@ async def sign_tx(tx: SignTx, root: bip32.HDNode):
             tx_ser.serialized_tx = w_txi_sign
 
             tx_req.serialized = tx_ser
+
+        elif coin.decred:
+            txi_sign = await request_tx_input(tx_req, i_sign)
+
+            input_check_wallet_path(txi_sign, wallet_path)
+
+            w_txi = empty_bytearray(7 + len(txi_sign.prev_hash) + 9)
+            if i_sign == 0:  # serializing first input => prepend headers
+                write_bytes(w_txi, get_tx_header(coin, tx, False))
+
+            write_tx_input_decred(w_txi, txi_sign)
+            write_tx_input_decred(h_prefix_sign, txi_sign)
+            tx_ser.serialized_tx = w_txi
+            tx_req.serialized = tx_ser
+            write_tx_input_check(h_second, txi_sign)
+            write_tx_input_check(h_third, txi_sign)
 
         else:
             # hash of what we are signing with this input
@@ -292,7 +338,7 @@ async def sign_tx(tx: SignTx, root: bip32.HDNode):
                         )
                     elif txi_sign.script_type == InputScriptType.SPENDADDRESS:
                         txi_sign.script_sig = output_script_p2pkh(
-                            ecdsa_hash_pubkey(key_sign_pub)
+                            ecdsa_hash_pubkey(key_sign_pub, coin)
                         )
                         if coin.bip115:
                             txi_sign.script_sig += script_replay_protection_bip115(
@@ -361,12 +407,19 @@ async def sign_tx(tx: SignTx, root: bip32.HDNode):
         txo = await request_tx_output(tx_req, o)
         txo_bin.amount = txo.amount
         txo_bin.script_pubkey = output_derive_script(txo, coin, root)
+        if coin.decred:
+            txo_bin.decred_script_version = txo.decred_script_version
 
         # serialize output
         w_txo_bin = empty_bytearray(5 + 8 + 5 + len(txo_bin.script_pubkey) + 4)
         if o == 0:  # serializing first output => prepend outputs count
             write_varint(w_txo_bin, tx.outputs_count)
+            if coin.decred:
+                write_varint(h_prefix_sign, tx.outputs_count)
         write_tx_output(w_txo_bin, txo_bin)
+        if coin.decred:
+            write_tx_output(h_prefix_sign, txo_bin)
+            write_tx_output(h_second, txo_bin)
 
         tx_ser.signature_index = None
         tx_ser.signature = None
@@ -375,6 +428,18 @@ async def sign_tx(tx: SignTx, root: bip32.HDNode):
         tx_req.serialized = tx_ser
 
     any_segwit = True in segwit.values()
+
+    prefix_hash = None
+    if coin.decred:
+        if get_tx_hash(h_first, False) != get_tx_hash(h_second):
+            raise SigningError(
+                FailureType.ProcessError, "Transaction has changed during signing"
+            )
+        write_uint32(h_prefix_sign, tx.lock_time)
+        write_uint32(h_prefix_sign, tx.expiry)
+        prefix_hash = get_tx_hash(
+            h_prefix_sign, double=coin.sign_hash_double, reverse=False
+        )
 
     for i in range(tx.inputs_count):
         progress.advance()
@@ -396,7 +461,11 @@ async def sign_tx(tx: SignTx, root: bip32.HDNode):
             key_sign = node_derive(root, txi.address_n)
             key_sign_pub = key_sign.public_key()
             hash143_hash = hash143.preimage_hash(
-                coin, tx, txi, ecdsa_hash_pubkey(key_sign_pub), get_hash_type(coin)
+                coin,
+                tx,
+                txi,
+                ecdsa_hash_pubkey(key_sign_pub, coin),
+                get_hash_type(coin),
             )
 
             signature = ecdsa_sign(key_sign, hash143_hash)
@@ -416,10 +485,75 @@ async def sign_tx(tx: SignTx, root: bip32.HDNode):
             tx_ser.serialized_tx = bytearray(1)  # empty witness for non-segwit inputs
             tx_ser.signature_index = None
             tx_ser.signature = None
+        elif coin.decred:
+            txi = await request_tx_input(tx_req, i)
+            input_check_wallet_path(txi, wallet_path)
+
+            write_tx_input_check(h_fourth, txi)
+
+            key_sign = node_derive(root, txi.address_n)
+            key_sign_pub = key_sign.public_key()
+
+            if txi.script_type == InputScriptType.SPENDMULTISIG:
+                prev_pkscript = output_script_multisig(
+                    multisig_get_pubkeys(txi.multisig), txi.multisig.m
+                )
+            elif txi.script_type == InputScriptType.SPENDADDRESS:
+                prev_pkscript = output_script_p2pkh(
+                    ecdsa_hash_pubkey(key_sign_pub, coin)
+                )
+            else:
+                raise ValueError("Unknown input script type")
+
+            h_witness = HashWriter(blake256)
+            write_uint32(h_witness, tx.version | DECRED_SERIALIZE_WITNESS_SIGNING)
+            write_varint(h_witness, tx.inputs_count)
+
+            for ii in range(tx.inputs_count):
+                if ii == i:
+                    write_varint(h_witness, len(prev_pkscript))
+                    write_bytes(h_witness, prev_pkscript)
+                else:
+                    write_varint(h_witness, 0)
+
+            witness_hash = get_tx_hash(
+                h_witness, double=coin.sign_hash_double, reverse=False
+            )
+
+            h_sign = HashWriter(blake256)
+            write_uint32(h_sign, 1)  # SIGHASHALL
+            write_bytes(h_sign, prefix_hash)
+            write_bytes(h_sign, witness_hash)
+
+            sig_hash = get_tx_hash(h_sign, double=coin.sign_hash_double)
+            signature = ecdsa_sign(key_sign, sig_hash)
+            tx_ser.signature_index = i
+            tx_ser.signature = signature
+
+            # serialize input with correct signature
+            txi.script_sig = input_derive_script(coin, txi, key_sign_pub, signature)
+            w_txi_sign = empty_bytearray(
+                10 + len(txi.prev_hash) + 18 + len(txi.script_sig)
+            )
+
+            if i == 0:
+                write_uint32(w_txi_sign, tx.lock_time)
+                write_uint32(w_txi_sign, tx.expiry)
+                write_varint(w_txi_sign, tx.inputs_count)
+
+            write_tx_input_decred_witness(w_txi_sign, txi)
+            tx_ser.serialized_tx = w_txi_sign
 
         tx_req.serialized = tx_ser
 
-    write_uint32(tx_ser.serialized_tx, tx.lock_time)
+    if coin.decred:
+        if get_tx_hash(h_third, False) != get_tx_hash(h_fourth):
+            raise SigningError(
+                FailureType.ProcessError, "Transaction has changed during signing"
+            )
+    else:
+        write_uint32(tx_ser.serialized_tx, tx.lock_time)
+
     if tx.overwintered:
         write_uint32(tx_ser.serialized_tx, tx.expiry)  # expiryHeight
         write_varint(tx_ser.serialized_tx, 0)  # nJoinSplit
@@ -435,11 +569,16 @@ async def get_prevtx_output_value(
     # STAGE_REQUEST_2_PREV_META
     tx = await request_tx_meta(tx_req, prev_hash)
 
-    txh = HashWriter(sha256)
+    if coin.decred:
+        txh = HashWriter(blake256)
+    else:
+        txh = HashWriter(sha256)
 
     if tx.overwintered:
         write_uint32(txh, tx.version | OVERWINTERED)  # nVersion | fOverwintered
         write_uint32(txh, coin.version_group_id)  # nVersionGroupId
+    elif coin.decred:
+        write_uint32(txh, tx.version | DECRED_SERIALIZE_NO_WITNESS)
     else:
         write_uint32(txh, tx.version)  # nVersion
 
@@ -448,7 +587,10 @@ async def get_prevtx_output_value(
     for i in range(tx.inputs_cnt):
         # STAGE_REQUEST_2_PREV_INPUT
         txi = await request_tx_input(tx_req, i, prev_hash)
-        write_tx_input(txh, txi)
+        if coin.decred:
+            write_tx_input_decred(txh, txi)
+        else:
+            write_tx_input(txh, txi)
 
     write_varint(txh, tx.outputs_cnt)
 
@@ -458,10 +600,19 @@ async def get_prevtx_output_value(
         write_tx_output(txh, txo_bin)
         if o == prev_index:
             total_out += txo_bin.amount
+            if (
+                coin.decred
+                and txo_bin.decred_script_version is not None
+                and txo_bin.decred_script_version != 0
+            ):
+                raise SigningError(
+                    FailureType.ProcessError,
+                    "Cannot use utxo that has script_version != 0",
+                )
 
     write_uint32(txh, tx.lock_time)
 
-    if tx.overwintered:
+    if tx.overwintered or coin.decred:
         write_uint32(txh, tx.expiry)
 
     ofs = 0
@@ -626,7 +777,7 @@ def input_derive_script(
             return input_script_p2wsh_in_p2sh(witness_script_hash)
 
         # p2wpkh in p2sh
-        return input_script_p2wpkh_in_p2sh(ecdsa_hash_pubkey(pubkey))
+        return input_script_p2wpkh_in_p2sh(ecdsa_hash_pubkey(pubkey, coin))
 
     elif i.script_type == InputScriptType.SPENDWITNESS:
         # native p2wpkh or p2wsh
@@ -636,7 +787,7 @@ def input_derive_script(
         # p2sh multisig
         signature_index = multisig_pubkey_index(i.multisig, pubkey)
         return input_script_multisig(
-            i.multisig, signature, signature_index, get_hash_type(coin)
+            i.multisig, signature, signature_index, get_hash_type(coin), coin
         )
 
     else:

--- a/src/apps/wallet/sign_tx/writers.py
+++ b/src/apps/wallet/sign_tx/writers.py
@@ -5,10 +5,13 @@ from trezor.messages.TxOutputBinType import TxOutputBinType
 from apps.common.writers import (
     write_bytes,
     write_bytes_reversed,
+    write_uint8,
+    write_uint16_le,
     write_uint32_le,
     write_uint64_le,
 )
 
+write_uint16 = write_uint16_le
 write_uint32 = write_uint32_le
 write_uint64 = write_uint64_le
 
@@ -32,8 +35,25 @@ def write_tx_input_check(w, i: TxInputType):
     write_uint32(w, i.amount or 0)
 
 
+def write_tx_input_decred(w, i: TxInputType):
+    write_bytes_reversed(w, i.prev_hash)
+    write_uint32(w, i.prev_index or 0)
+    write_uint8(w, i.decred_tree or 0)
+    write_uint32(w, i.sequence)
+
+
+def write_tx_input_decred_witness(w, i: TxInputType):
+    write_uint64(w, i.amount or 0)
+    write_uint32(w, 0)  # block height fraud proof
+    write_uint32(w, 0xFFFFFFFF)  # block index fraud proof
+    write_varint(w, len(i.script_sig))
+    write_bytes(w, i.script_sig)
+
+
 def write_tx_output(w, o: TxOutputBinType):
     write_uint64(w, o.amount)
+    if o.decred_script_version is not None:
+        write_uint16(w, o.decred_script_version)
     write_varint(w, len(o.script_pubkey))
     write_bytes(w, o.script_pubkey)
 

--- a/src/apps/wallet/verify_message.py
+++ b/src/apps/wallet/verify_message.py
@@ -51,7 +51,7 @@ async def verify_message(ctx, msg):
     elif script_type == SPENDP2SHWITNESS:
         addr = address_p2wpkh_in_p2sh(pubkey, coin)
     elif script_type == SPENDWITNESS:
-        addr = address_p2wpkh(pubkey, coin.bech32_prefix)
+        addr = address_p2wpkh(pubkey, coin)
     else:
         raise wire.ProcessError("Invalid signature")
 

--- a/src/trezor/crypto/base58.py
+++ b/src/trezor/crypto/base58.py
@@ -71,6 +71,12 @@ def groestl512d_32(data: bytes) -> bytes:
     return groestl512(groestl512(data).digest()).digest()[:4]
 
 
+def blake256_32(data: bytes) -> bytes:
+    from .hashlib import blake256
+
+    return blake256(blake256(data).digest()).digest()[:4]
+
+
 def encode_check(data: bytes, digestfunc=sha256d_32) -> str:
     """
     Convert bytes to base58 encoded string, append checksum.

--- a/tests/test_apps.wallet.address.py
+++ b/tests/test_apps.wallet.address.py
@@ -41,7 +41,7 @@ class TestAddress(unittest.TestCase):
         coin = coins.by_name('Testnet')
         address = address_p2wpkh(
             unhexlify('0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798'),
-            coin.bech32_prefix
+            coin
         )
         self.assertEqual(address, 'tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx')
 

--- a/tests/test_apps.wallet.address_grs.py
+++ b/tests/test_apps.wallet.address_grs.py
@@ -60,15 +60,15 @@ class TestAddressGRS(unittest.TestCase):
         root = bip32.from_seed(seed, coin.curve_name)
 
         node = node_derive(root, [84 | 0x80000000, 17 | 0x80000000, 0 | 0x80000000, 1, 0])
-        address = address_p2wpkh(node.public_key(), coin.bech32_prefix)
+        address = address_p2wpkh(node.public_key(), coin)
         self.assertEqual(address, 'grs1qzfpwn55tvkxcw0xwfa0g8k2gtlzlgkcq3z000e')
 
         node = node_derive(root, [84 | 0x80000000, 17 | 0x80000000, 0 | 0x80000000, 1, 1])
-        address = address_p2wpkh(node.public_key(), coin.bech32_prefix)
+        address = address_p2wpkh(node.public_key(), coin)
         self.assertEqual(address, 'grs1qxsgwl66tx7tsuwfm4kk5c5dh6tlfpr4qjqg6gg')
 
         node = node_derive(root, [84 | 0x80000000, 17 | 0x80000000, 0 | 0x80000000, 0, 0])
-        address = address_p2wpkh(node.public_key(), coin.bech32_prefix)
+        address = address_p2wpkh(node.public_key(), coin)
         self.assertEqual(address, 'grs1qw4teyraux2s77nhjdwh9ar8rl9dt7zww8r6lne')
 
 


### PR DESCRIPTION
Sending for early review to know whether the approach is acceptable for inclusion.

I've roughly followed what was done in trezor-mcu: adding a few conditional checks for decred then customizing where needed.

Please advise on whether this approach will be acceptable so I can do some clean up and improvements or if you'd prefer a more modular implementation (eg: creating a `sign_tx_decred`, `get_prev_output_value_decred`, etc).