### PR TITLE
emulator debug build options and persistent flash across runtimes

### DIFF
--- a/SConscript.unix
+++ b/SConscript.unix
@@ -221,6 +221,7 @@ SOURCE_UNIX = [
     'vendor/micropython/ports/unix/input.c',
     'vendor/micropython/ports/unix/alloc.c',
     'embed/unix/common.c',
+    'embed/unix/profile.c',
     'embed/unix/flash.c',
     'embed/unix/main.c',
     'embed/unix/rng.c',

--- a/SConscript.unix
+++ b/SConscript.unix
@@ -246,11 +246,24 @@ env.Replace(
     STRIP='strip',
     OBJCOPY='objcopy', )
 
+if env.get('ENV').get('DEBUG_BUILD', 0):
+    env.Replace(
+        OPTIMIZE='-O0',
+        LINKFLAGS='-Wl,-no-pie'
+    )
+
+    import platform
+    platsys = platform.system()
+    if platsys == "Darwin":
+        env.Replace(
+            LINKFLAGS='-Wl,-no_pie'
+        )
+
 env.Replace(
     TREZOR_MODEL=env.get('ENV').get('TREZOR_MODEL', 'T'), )
 
 env.Replace(
-    COPT=env.get('ENV').get('OPTIMIZE', '-Os'),
+    COPT=env.get('OPTIMIZE', env.get('ENV').get('OPTIMIZE', '-Os')),
     CCFLAGS='$COPT '
     '-g3 '
     '-std=gnu99 -Wall -Werror -Wuninitialized '

--- a/docs/build.md
+++ b/docs/build.md
@@ -98,3 +98,31 @@ Use `make upload` to upload the firmware to a production device (with a bootload
 For flashing firmware to blank device (without bootloader) use `make flash`,
 or `make flash STLINK_VER=v2-1` if using a ST-LINK/V2.1 interface.
 You need to have OpenOCD installed.
+
+
+## Building for debugging and hacking in Emulator (Unix port)
+
+Build the debuggable unix binary so you can attach the gdb or lldb.
+This removes optimizations and reduces address space randomizaiton.
+Beware that this will significantly bloat the final binary
+and the firmware runtime memory limit HEAPSIZE may have to be increased.
+
+```sh
+DEBUG_BUILD=1 make build_unix
+```
+
+To prevent the emulator from deleting the flash cache you need tobuild the hotpatch tool.
+
+```sh
+cd tools/hotpatch
+make
+cd -
+```
+
+Now you can run the emulator repeatedly without loosing configuration like so:
+
+```sh
+HEAPSIZE=50M ./emu.sh --persist
+```
+
+

--- a/docs/emulator.md
+++ b/docs/emulator.md
@@ -5,3 +5,23 @@
 1. [build](build.md) the emulator
 2. run `emu.sh`
 3. to use [bridge](https://github.com/trezor/trezord-go) with the emulator support, start it with `trezord -e 21324`
+
+## Profiles
+
+To run emulator with different flash and sdcard files set the environment
+variable **TREZOR_PROFILE** like so:
+
+```sh
+TREZOR_PROFILE=foobar ./emu.sh
+```
+
+This will create a profile directory in your home ``` ~/.trezoremu/foobar```
+containing emulator run files.
+
+Alternatively you can set a full path like so:
+
+```sh
+TREZOR_PROFILE=/var/tmp/foobar ./emu.sh
+```
+
+When the **TREZOR_PROFILE** is not set the default is ```/var/tmp``` .

--- a/embed/trezorhal/touch.h
+++ b/embed/trezorhal/touch.h
@@ -32,8 +32,8 @@ void touch_power_off(void);
 uint32_t touch_read(void);
 uint32_t touch_click(void);
 uint32_t touch_is_detected(void);
-inline uint16_t touch_unpack_x(uint32_t evt) { return (evt >> 12) & 0xFFF; }
-inline uint16_t touch_unpack_y(uint32_t evt) { return (evt >> 0) & 0xFFF; }
-inline uint32_t touch_pack_xy(uint16_t x, uint16_t y) { return ((x & 0xFFF) << 12) | (y & 0xFFF); }
+static inline uint16_t touch_unpack_x(uint32_t evt) { return (evt >> 12) & 0xFFF; }
+static inline uint16_t touch_unpack_y(uint32_t evt) { return (evt >> 0) & 0xFFF; }
+static inline uint32_t touch_pack_xy(uint16_t x, uint16_t y) { return ((x & 0xFFF) << 12) | (y & 0xFFF); }
 
 #endif

--- a/embed/unix/flash.c
+++ b/embed/unix/flash.c
@@ -27,9 +27,10 @@
 
 #include "common.h"
 #include "flash.h"
+#include "profile.h"
 
 #ifndef FLASH_FILE
-#define FLASH_FILE "/var/tmp/trezor.flash"
+#define FLASH_FILE profile_flash_path()
 #endif
 
 #define SECTOR_COUNT 24

--- a/embed/unix/main.c
+++ b/embed/unix/main.c
@@ -48,6 +48,7 @@
 #include "extmod/misc.h"
 #include "genhdr/mpversion.h"
 #include "input.h"
+#include "profile.h"
 
 // Command line options, with their defaults
 STATIC bool compile_only = false;
@@ -404,6 +405,10 @@ STATIC void set_sys_argv(char *argv[], int argc, int start_arg) {
 MP_NOINLINE int main_(int argc, char **argv);
 
 int main(int argc, char **argv) {
+    
+    // Through TREZOR_PROFILE you can set the directory for trezor.flash file.
+    profile_init();
+
     #if MICROPY_PY_THREAD
     mp_thread_init();
     #endif

--- a/embed/unix/profile.c
+++ b/embed/unix/profile.c
@@ -1,0 +1,117 @@
+/*
+ * This file is part of the TREZOR project, https://trezor.io/
+ *
+ * Copyright (c) SatoshiLabs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/errno.h>
+#include <libgen.h>
+#include <unistd.h>
+
+#include "profile.h"
+#include "common.h"
+
+int mkpath(char *path, mode_t mode) {
+    if (!path) {
+        errno = EINVAL;
+        return 1;
+    }
+    
+    struct stat sb;
+    if (!stat(strdup(path), &sb)) {
+        return 0;
+    }
+
+    // dirname has multiple incompatible implementations.
+    // Some modify input argument some share output buffer.
+    char *pathdup = strdup(path);
+    char *subpath = strdup(dirname(pathdup));
+    mkpath(subpath, mode);
+    free(pathdup);
+    free(subpath);
+    return mkdir(path, mode);
+}
+
+void profile_init() {
+    char *dir = profile_dir();
+    if (mkpath(dir, 0755)) {
+        perror(dir);
+        printf("!!! Unable to initialize profile directory `%s`. Quitting\n", dir);
+        exit(1);
+    }
+    printf("Profile directory: %s\n", dir);
+}
+
+char* profile_dir() {
+    static char *_profile_dir;
+    
+    if (_profile_dir) {
+        return _profile_dir;
+    }
+
+    char *trezor_profile = getenv("TREZOR_PROFILE");
+    if (!trezor_profile || strlen(trezor_profile) < 1) {
+        trezor_profile = PROFILE_DEFAULT;
+    }
+
+    char *path;
+    if (trezor_profile[0] == '/') {
+    // TREZOR_PROFILE is a full path to profile directory
+        path = strdup(trezor_profile);
+    } else {
+    // TREZOR_PROFILE is just a profile name and will be put in ~/.trezoremu/
+        asprintf(&path, "%s/" PROFILE_HOMEDOT "/%s/", getenv("HOME"), trezor_profile);
+    }
+
+    _profile_dir = path;
+
+    return _profile_dir;
+}
+
+char* profile_flash_path() {
+    static char* _flash_path;
+    if (_flash_path)
+        return _flash_path;
+
+    asprintf(&_flash_path, "%s/trezor.flash", profile_dir());
+
+    if (!_flash_path) { // last resort fallback
+        _flash_path = "/var/tmp/trezor.flash";
+    }
+
+    return _flash_path;
+}
+
+char* profile_sdcard_path() {
+    static char* _sdcard_path;
+    if (_sdcard_path)
+        return _sdcard_path;
+
+    asprintf(&_sdcard_path, "%s/trezor.sdcard", profile_dir());
+
+    if (!_sdcard_path) { // last resort fallback
+        _sdcard_path = "/var/tmp/trezor.sdcard";
+    }
+
+    return _sdcard_path;
+}
+
+
+

--- a/embed/unix/profile.h
+++ b/embed/unix/profile.h
@@ -1,0 +1,41 @@
+/*
+ * This file is part of the TREZOR project, https://trezor.io/
+ *
+ * Copyright (c) SatoshiLabs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef __TREZOR_PROFILE_H__
+#define __TREZOR_PROFILE_H__
+
+// TREZOR_PROFILE environment variable can be a full path
+// or just a name that will result in the path:
+//   ~/${PROFILE_HOMEDOT}/${TREZOR_PROFILE}
+// If the variable is not set the default is ${PROFILE_DEFAULT}
+
+#ifndef PROFILE_DEFAULT
+#define PROFILE_DEFAULT "/var/tmp"
+#endif
+
+#ifndef PROFILE_HOMEDOT
+#define PROFILE_HOMEDOT ".trezoremu"
+#endif
+
+void profile_init();
+char* profile_dir();
+char* profile_flash_path();
+char* profile_sdcard_path();
+
+#endif // __TREZOR_PROFILE_H__

--- a/embed/unix/sdcard.c
+++ b/embed/unix/sdcard.c
@@ -27,9 +27,10 @@
 
 #include "common.h"
 #include "sdcard.h"
+#include "profile.h"
 
 #ifndef SDCARD_FILE
-#define SDCARD_FILE "/var/tmp/trezor.sdcard"
+#define SDCARD_FILE profile_sdcard_path()
 #endif
 
 #define SDCARD_SIZE (32 * 1024 * 1024)

--- a/emu.sh
+++ b/emu.sh
@@ -4,16 +4,34 @@ source emu.config 2>/dev/null
 
 EXE=build/unix/micropython
 PYOPT="${PYOPT:-1}"
-MAIN="${MAIN:-main.py}"
+MAIN="${MAIN:-${PWD}/src/main.py}"
 BROWSER="${BROWSER:-chromium}"
-HEAPSIZE="${HEAPSIZE:-800K}"
+HEAPSIZE="${HEAPSIZE:-50M}"
 SOURCE_PY_DIR="${SOURCE_PY_DIR:-src}"
 
 ARGS="-O${PYOPT} -X heapsize=${HEAPSIZE}"
 
+OPERATING_SYSTEM=$(uname)
+
+LIB_OVERRIDE_PATH="${PWD}/tools/hotpatch/lib_overrides.so"
+ENV_LIB_OVERRIDE="LD_PRELOAD=${LIB_OVERRIDE_PATH}"
+if [ $OPERATING_SYSTEM == "Darwin" ]; then
+    ENV_LIB_OVERRIDE="DYLD_INSERT_LIBRARIES=${LIB_OVERRIDE_PATH}"
+fi
+
 cd `dirname $0`/$SOURCE_PY_DIR
 
 case "$1" in
+    # persist the flash memory upon exit so you don't need to reinitalize the device every run
+    "--persist")
+        shift
+        DYLD_FORCE_FLAT_NAMESPACE=1 DYLD_INSERT_LIBRARIES=${LIB_OVERRIDE_PATH} ../$EXE $ARGS $* $MAIN
+        ;;
+    "--persist-lldb")
+        shift
+        LLDB_SET_ENV="settings set target.env-vars ${ENV_LIB_OVERRIDE}"
+        PATH=/usr/bin /usr/bin/lldb -s <(echo "${LLDB_SET_ENV}") -f ../$EXE -- $ARGS $* $MAIN
+        ;;
     "-d")
         shift
         gdb --args ../$EXE $ARGS $* $MAIN

--- a/tools/hotpatch/.gitignore
+++ b/tools/hotpatch/.gitignore
@@ -1,0 +1,2 @@
+lib_overrides.so
+

--- a/tools/hotpatch/Makefile
+++ b/tools/hotpatch/Makefile
@@ -1,0 +1,8 @@
+
+CC = gcc
+
+lib_overrides.so:
+	$(CC) $(CFLAGS) ${LDFLAGS} -Wall -dynamiclib -o $@ lib_overrides.c
+
+all: lib_overrides.so
+

--- a/tools/hotpatch/lib_overrides.c
+++ b/tools/hotpatch/lib_overrides.c
@@ -1,0 +1,38 @@
+#include <dlfcn.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <string.h>
+
+static int PAGE_SIZE;
+
+#define FUN_SIZE(fun) (fun##_end-fun)
+#define PTR_PAGE_ALIGN(ptr) \
+  (void*)((unsigned long long)ptr & (unsigned long long)(~(PAGE_SIZE-1)))
+
+void override_void_void(void) {};
+void override_void_void_end(void) {};
+
+static void override_constructor() __attribute__((constructor));
+void override_constructor() {
+  printf("### binary_override_start\n");
+
+  PAGE_SIZE = getpagesize();
+
+  // override storage_wipe with empty function
+
+    // get storage_wipe memory location
+  void* sym_ptr = dlsym(RTLD_DEFAULT, "storage_wipe");
+  void* page_ptr = PTR_PAGE_ALIGN(sym_ptr);
+  long fun_size = FUN_SIZE(override_void_void);
+
+  printf("### storage_wipe <<< void(void) @ %p ! %p : %ld\n", sym_ptr, page_ptr, fun_size);
+
+    // unprotect memory page
+  if (mprotect(page_ptr, PAGE_SIZE, PROT_READ|PROT_WRITE|PROT_EXEC) != 0) {
+    perror("error");
+  }
+    // override function bytes
+  bcopy(override_void_void, sym_ptr, FUN_SIZE(override_void_void));
+}
+


### PR DESCRIPTION
Handy patches to make the emulator more debug friendly.
1. Patched emulator build script for consistent debug builds.
2. Hotpatch tool for emulator to prevent flash wipe when running with PYOPT=0
