### PR TITLE
Tezos: delegating contract in origination

### DIFF
--- a/src/apps/tezos/sign_tx.py
+++ b/src/apps/tezos/sign_tx.py
@@ -27,6 +27,12 @@ async def sign_tx(ctx, msg):
     elif msg.origination is not None:
         source = _get_address_from_contract(msg.origination.source)
         await require_confirm_origination(ctx, source)
+
+        # if we are immediately delegating contract
+        if msg.origination.delegate is not None:
+            delegate = _get_address_by_tag(msg.origination.delegate)
+            await require_confirm_delegation_baker(ctx, delegate)
+
         await require_confirm_origination_fee(
             ctx, msg.origination.balance, msg.origination.fee
         )


### PR DESCRIPTION
When creating contract, the user can immediately delegate it to baker. Therefore, we need to show this information on the screen, so we improve the security of setting that delegate.

Signed-off-by: Adrian Matejov <adrian.matejov@simplestaking.com>