### PR TITLE
xmr: fixes sending to self with stealth payment ID

### DIFF
--- a/src/apps/monero/signing/step_01_init_transaction.py
+++ b/src/apps/monero/signing/step_01_init_transaction.py
@@ -353,6 +353,9 @@ def _get_key_for_payment_id_encryption(destinations: list, change_addr=None):
         addr = dest.addr
         count += 1
 
+    if count == 0 and change_addr:
+        return change_addr.view_public_key
+
     if addr.view_public_key == crypto.NULL_KEY_ENC:
         raise ValueError("Invalid key")
 


### PR DESCRIPTION
Fixes a bug when sending to the wallet address with stealth payment ID.

https://github.com/monero-project/monero/blob/4cbb476cd1f215926d3cc2b4ff6f397ffa5f347b/src/cryptonote_core/cryptonote_tx_utils.cpp#L196

