### PR TITLE
xmr: sort extra fields

### DIFF
--- a/src/apps/monero/signing/state.py
+++ b/src/apps/monero/signing/state.py
@@ -109,6 +109,8 @@ class State:
 
         # simple stub containing items hashed into tx prefix
         self.tx = TprefixStub(vin=[], vout=[], extra=b"")
+        # TX_EXTRA_NONCE extra field for tx.extra, due to sort_tx_extra()
+        self.extra_nonce = None
 
         # contains an array where each item denotes the input's position
         # (inputs are sorted by key images)

--- a/src/apps/monero/signing/step_01_init_transaction.py
+++ b/src/apps/monero/signing/step_01_init_transaction.py
@@ -324,7 +324,7 @@ def _process_payment_id(state: State, tsx_data: MoneroTransactionData):
     extra_buff[1] = lextra + 1
     extra_buff[2] = extra_prefix
     extra_buff[3:] = extra_nonce
-    state.tx.extra = extra_buff
+    state.extra_nonce = extra_buff
 
 
 def _get_key_for_payment_id_encryption(destinations: list, change_addr=None):


### PR DESCRIPTION
Monero implemented sorting fields in the `tx.extra` in the https://github.com/monero-project/monero/blob/557c17e206c697174982d28636a29c149f07f630/src/cryptonote_core/cryptonote_tx_utils.cpp#L88

The tag ordering is:
- `TX_EXTRA_TAG_PUBKEY`
- `TX_EXTRA_TAG_ADDITIONAL_PUBKEYS`
- `TX_EXTRA_NONCE`

I've implemented a small change that preserves this ordering on the Trezor so transactions do not leak info (ordering can indicate signer of the transaction) to the blockchain.

The only required change was to move `TX_EXTRA_NONCE` to the end of the extra field - so I've added `state.extra_nonce` field which is added to the `tx.extra` after all previous tags are in place.

I've also did some small refactoring to minimize buffer reallocation for extras. 