### PR TITLE
xmr: key image sync progress info

### DIFF
--- a/src/apps/monero/key_image_sync.py
+++ b/src/apps/monero/key_image_sync.py
@@ -70,6 +70,8 @@ async def _sync_step(s, ctx, tds):
     buff = bytearray(32 * 3)
     buff_mv = memoryview(buff)
 
+    await confirms.keyimage_sync_step(ctx, s.current_output, s.num_outputs)
+
     for td in tds.tdis:
         s.current_output += 1
         if s.current_output >= s.num_outputs:

--- a/src/apps/monero/layout/confirms.py
+++ b/src/apps/monero/layout/confirms.py
@@ -123,3 +123,12 @@ async def transaction_step(ctx, step, sub_step=None, sub_step_total=None):
     text = Text("Signing transaction", ui.ICON_SEND, icon_color=ui.BLUE)
     text.normal(*info)
     text.render()
+
+
+@ui.layout
+async def keyimage_sync_step(ctx, current, total_num):
+    if current is None:
+        return
+    text = Text("Syncing", ui.ICON_SEND, icon_color=ui.BLUE)
+    text.normal("%d/%d" % (current + 1, total_num))
+    text.render()


### PR DESCRIPTION
Adds very simple progress view for key image sync so user knows Trezor is working on the sync (otherwise it could look like something went wrong / frozen)