### PR TITLE
Added missing package for OS X

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -44,7 +44,7 @@ Install the required packages, depending on your operating system.
 * __Mac OS X__:
 
   ```sh
-  brew install scons sdl2 sdl2_image
+  brew install scons sdl2 sdl2_image pkg-config
   ```
 
 * __Windows__: not supported yet, sorry.


### PR DESCRIPTION
This package was missing while build (``` make build_unix ```)

![image](https://user-images.githubusercontent.com/3112191/48342384-cf641080-e66f-11e8-84e2-8012e96a2d55.png)
