### PR TITLE
make help - typo fix, add spacing & refactor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ CFLAGS += -DGITREV=$(GITREV)
 ## help commands:
 
 help: ## show this help
-	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z0-9_-]+:.*?## / {printf "\033[36m  make %-20s\033[0m %s\n", $$1, $$2} /^##(.*)/ {printf "\033[33m%s\n", substr($$0, 4)}' $(MAKEFILE_LIST)
+	@awk 'BEGIN {FS = ":.*?## "; first = 1;} /^[a-zA-Z0-9_-]+:.*?## / {printf "\033[36m  make %-20s\033[0m %s\n", $$1, $$2} /^##(.*)/ {if (!first) printf "\n"; printf "\033[33m%s\n", substr($$0, 4); first=0;}' $(MAKEFILE_LIST)
 
 ## dependencies commands:
 

--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ black:
 cstyle: ## run code style check on low-level C code
 	./tools/clang-format-check $(shell find embed -type f -name *.[ch])
 
-## code generation ##
+## code generation:
 
 templates: ## render Mako templates (for lists of coins, tokens, etc.)
 	./tools/build_templates

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ CFLAGS += -DGITREV=$(GITREV)
 ## help commands:
 
 help: ## show this help
-	@awk 'BEGIN {FS = ":.*?## "; first = 1;} /^[a-zA-Z0-9_-]+:.*?## / {printf "\033[36m  make %-20s\033[0m %s\n", $$1, $$2} /^##(.*)/ {if (!first) printf "\n"; printf "\033[33m%s\n", substr($$0, 4); first=0;}' $(MAKEFILE_LIST)
+	@awk -f help.awk $(MAKEFILE_LIST)
 
 ## dependencies commands:
 

--- a/help.awk
+++ b/help.awk
@@ -1,0 +1,20 @@
+#!/usr/bin/env awk
+
+BEGIN {
+    FS = ":.*?## "
+    first = 1
+    COLOR_BROWN = "\033[33m"
+    COLOR_DARKGREEN = "\033[36m"
+    COLOR_RESET = "\033[0m"
+} /^[a-zA-Z0-9_-]+:.*?## / { 
+    printf COLOR_DARKGREEN
+    printf "  make %-20s", $1
+    printf COLOR_RESET
+    printf " %s\n", $2
+} /^##(.*)/ { 
+    if (!first)
+        printf "\n"
+    printf "%s%s\n", COLOR_BROWN, substr($0, 4)
+    first = 0
+}
+


### PR DESCRIPTION
1. Fixed "code generation" label (there was ` ##` instead of `:`)
2. Added nice spacing after each group of commands.
3. Moved the awk command to a separate file for readability.
