### PR TITLE
Fixing make test_emu in some environments.

### DIFF
--- a/tests/run_tests_device_emu.sh
+++ b/tests/run_tests_device_emu.sh
@@ -12,7 +12,7 @@ sleep 1
 export TREZOR_PATH=udp:127.0.0.1:21324
 
 # run tests
-cd ../tests
+cd ..
 error=0
 if ! pytest "$@"; then
     error=1


### PR DESCRIPTION
Running `make test_emu` in trezor-core doesn't work for me. trezor-core/tests/unittest.py overshadows the standard library unittest, so pytest is unable to start at all (exception below). 
```
(trezor-core) bash-3.2$ make test_emu
cd tests ; ./run_tests_device_emu.sh 
Traceback (most recent call last):
  File "/Users/tibor/.virtualenvs/trezor-core-JdiA6MQI/bin/pytest", line 7, in <module>
    from pytest import main
  File "/Users/tibor/.virtualenvs/trezor-core-JdiA6MQI/lib/python3.7/site-packages/pytest.py", line 13, in <module>
    from _pytest.debugging import pytestPDB as __pytestPDB
  File "/Users/tibor/.virtualenvs/trezor-core-JdiA6MQI/lib/python3.7/site-packages/_pytest/debugging.py", line 8, in <module>
    from doctest import UnexpectedException
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/doctest.py", line 104, in <module>
    import unittest
  File "/Users/tibor/cpc/trezor-core/tests/unittest.py", line 1, in <module>
    from trezor.utils import ensure
ModuleNotFoundError: No module named 'trezor'
make: *** [test_emu] Error 1
```
I've seen the test_emu target work for people but I'm not sure how.