### PR TITLE
xmr: payment ID computation fix

### DIFF
--- a/src/apps/monero/signing/step_01_init_transaction.py
+++ b/src/apps/monero/signing/step_01_init_transaction.py
@@ -373,7 +373,7 @@ def _encrypt_payment_id(payment_id, public_key, secret_key):
     derivation_p = crypto.generate_key_derivation(public_key, secret_key)
     derivation = bytearray(33)
     derivation = crypto.encodepoint_into(derivation, derivation_p)
-    derivation[32] = 0x8B
+    derivation[32] = 0x8D  # ENCRYPTED_PAYMENT_ID_TAIL
     hash = crypto.cn_fast_hash(derivation)
     pm_copy = bytearray(payment_id)
     for i in range(8):


### PR DESCRIPTION
Typo in tail differentiating tag caused invalid short payment id encryption. was 0x8B, should have been 0x8D.

Correct computation: 

```python
enc_payment_id = payment_id ^ cn_fast_hash(derivation + b'\x8D')
```

Tail tag `0x8D` was mistyped as `0x8B` which yields a different hash which is used for XOR. 
No funds are lost, but payment ID is incorrect which can cause payment linking problems when using exchanges / markets. 

Recipient of the message can recompute the payment ID:

```python
derivation = 8 * view_key_private * tx_key_public
correct_payment_id = enc_payment_id ^ cn_fast_hash(derivation + b'\x8D')
```

OR from the wrongly decrypted plain payment id:

```python
correct_payment_id = wrongly_decrypted_payment_id ^ cn_fast_hash(derivation + b'\x8D') ^ cn_fast_hash(derivation + b'\x8B')
```

Demonstration code that decodes payment ID correctly, takes transaction ID and secret view key:

https://gist.github.com/ph4r05/b95c085b101cd9c9ba5dad104dfab007

Sources:

- https://github.com/monero-project/monero/blob/69b646494b17a02e381128e54caebccf2d2b7729/src/device/device_default.cpp#L39
- https://github.com/monero-project/monero/blob/69b646494b17a02e381128e54caebccf2d2b7729/src/device/device_default.cpp#L287
- Fixes problem reported in https://www.reddit.com/r/TREZOR/comments/a0ugt8/problem_when_using_monero/