### PR TITLE
Find ideal value for touch screen sensitivity (aka threshold)

### DIFF
--- a/embed/prodtest/main.c
+++ b/embed/prodtest/main.c
@@ -224,6 +224,33 @@ static void test_touch(const char *args)
     touch_power_off();
 }
 
+static void test_sensitivity(const char *args)
+{
+    int v = atoi(args);
+
+    touch_power_on();
+    touch_sensitivity(v & 0xFF);
+
+    display_clear();
+    display_refresh();
+
+    for (;;) {
+        uint32_t evt = touch_read();
+        if (evt & TOUCH_START || evt & TOUCH_MOVE) {
+            int x = touch_unpack_x(evt);
+            int y = touch_unpack_y(evt);
+            display_clear();
+            display_bar(x - 48, y - 48, 96, 96, 0xFFFF);
+            display_refresh();
+        } else if (evt & TOUCH_END) {
+            display_clear();
+            display_refresh();
+        }
+    }
+
+    touch_power_off();
+}
+
 static void test_pwm(const char *args)
 {
     int v = atoi(args);
@@ -370,6 +397,9 @@ int main(void)
 
         } else if (startswith(line, "TOUCH ")) {
             test_touch(line + 6);
+
+        } else if (startswith(line, "SENS ")) {
+            test_sensitivity(line + 5);
 
         } else if (startswith(line, "PWM ")) {
             test_pwm(line + 4);

--- a/embed/trezorhal/touch.h
+++ b/embed/trezorhal/touch.h
@@ -29,6 +29,7 @@
 void touch_init(void);
 void touch_power_on(void);
 void touch_power_off(void);
+void touch_sensitivity(uint8_t value);
 uint32_t touch_read(void);
 uint32_t touch_click(void);
 uint32_t touch_is_detected(void);

--- a/embed/trezorhal/touch_1.h
+++ b/embed/trezorhal/touch_1.h
@@ -23,6 +23,8 @@ void touch_power_on(void) { }
 
 void touch_power_off(void) { }
 
+void touch_sensitivity(uint8_t value) { (void)value; }
+
 uint32_t touch_read(void)
 {
     static char last_left = 0, last_right = 0;

--- a/embed/trezorhal/touch_t.h
+++ b/embed/trezorhal/touch_t.h
@@ -109,6 +109,8 @@ void touch_power_on(void) {
     // set register 0xA4 G_MODE to interrupt polling mode (0x00). basically, CTPM keeps this input line (to PC4) low while a finger is on the screen.
     uint8_t touch_panel_config[] = {0xA4, 0x00};
     ensure(sectrue * (HAL_OK == HAL_I2C_Master_Transmit(&i2c_handle, TOUCH_ADDRESS, touch_panel_config, sizeof(touch_panel_config), 10)), NULL);
+
+    touch_sensitivity(0x06);
 }
 
 void touch_power_off(void) {
@@ -119,6 +121,12 @@ void touch_power_off(void) {
     // turn off CTP circuitry
     HAL_Delay(50);
     touch_default_pin_state();
+}
+
+void touch_sensitivity(uint8_t value) {
+    // set panel threshold (TH_GROUP) - default value is 0x12
+    uint8_t touch_panel_threshold[] = {0x80, value};
+    ensure(sectrue * (HAL_OK == HAL_I2C_Master_Transmit(&i2c_handle, TOUCH_ADDRESS, touch_panel_threshold, sizeof(touch_panel_threshold), 10)), NULL);
 }
 
 uint32_t touch_is_detected(void)


### PR DESCRIPTION
It is possible to set touch screen sensitivity. The default seems to be 0x12 (I read this value from 0x80 register), but maybe a lower value is a better choice. 

See the example of touch screen sensitivity issue here:  https://github.com/trezor/trezor-core/issues/402 (and video inside: https://youtu.be/cbt5-aXAhCw)

**Do not merge until we find out the ideal value!**