### PR TITLE
Add git pre-push hook to docs

### DIFF
--- a/docs/git/hooks/pre-push
+++ b/docs/git/hooks/pre-push
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+# Runs a simple check before pushing. In particular, this checks
+# if templates were regenerated and style is correct.
+# Put this file to `.git/hooks/`.
+
+echo "Running pre-push git hook."
+
+# Runs check for common simple errors before pushing
+if ! make templates_check &> /dev/null
+then
+    echo >&2 "Templates not updated, run 'make templates'. Not pushing."
+    exit 1
+fi
+
+if ! make style &> /dev/null
+then
+    echo >&2 "Style invalid, run style make commands. Not pushing."
+    exit 2
+fi
+
+echo "pre-push hook passed. Pushing."


### PR DESCRIPTION
Quite frequently my code fails on CI because I've simply forgotten to run `make templates` or `make style`. This git hook runs both and if the it does not succeed it aborts the push.

If interested, insert the file into `.git/hooks`.
