### PR TITLE
wallet/signing: clear extra_data fields after we're done with them

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -568,7 +568,7 @@
         "trezor": {
             "editable": true,
             "git": "https://github.com/trezor/python-trezor",
-            "ref": "369b704f6bf60e510e1fcb03b021ff1866894459"
+            "ref": "master"
         },
         "typing-extensions": {
             "hashes": [

--- a/src/apps/wallet/sign_tx/helpers.py
+++ b/src/apps/wallet/sign_tx/helpers.py
@@ -87,6 +87,8 @@ def request_tx_extra_data(
     tx_req.details.request_index = None
     ack = yield tx_req
     tx_req.serialized = None
+    tx_req.details.extra_data_offset = None
+    tx_req.details.extra_data_len = None
     return ack.tx.extra_data
 
 


### PR DESCRIPTION
otherwise the values are repeated in every subsequent TxRequest

this also fixes a build failure in the new Dash test, where the `TxRequestDetailsType` only specifies `request_index`, but actually receives the `extra_data` fields from the previous round.
This can also be fixed on python-trezor side (so that the child protobufs matching is relaxed, same as the top-level matching), but I decided to keep the strict equality check for now, as it allowed us to catch this minor bug :)