### PR TITLE
Show a waiting screen before bip39 derivation

### DIFF
--- a/src/apps/common/seed.py
+++ b/src/apps/common/seed.py
@@ -1,5 +1,6 @@
-from trezor import wire
+from trezor import ui, wire
 from trezor.crypto import bip32, bip39
+from trezor.ui.text import Text
 
 from apps.common import cache, storage
 from apps.common.request_passphrase import protect_by_passphrase
@@ -61,11 +62,19 @@ async def get_keychain(ctx: wire.Context, namespaces: list) -> Keychain:
         if passphrase is None:
             passphrase = await protect_by_passphrase(ctx)
             cache.set_passphrase(passphrase)
+        await layout_waiting_screen()
         seed = bip39.seed(storage.get_mnemonic(), passphrase)
         cache.set_seed(seed)
 
     keychain = Keychain(seed, namespaces)
     return keychain
+
+
+@ui.layout
+async def layout_waiting_screen():
+    text = Text("Deriving seed")
+    text.bold("Please wait...")
+    text.render()
 
 
 def derive_node_without_passphrase(


### PR DESCRIPTION
Right now just a textual waiting screen. We could do a loader, but that would require a callback from the bip39 seed derivation.

<img width="512" alt="screenshot 2019-01-10 at 14 33 21" src="https://user-images.githubusercontent.com/1055497/50971646-d202ab00-14e4-11e9-8c29-37fed0c21cc9.png">

Fixes #433 
