### PR TITLE
eth: get public key

### DIFF
--- a/src/apps/ethereum/__init__.py
+++ b/src/apps/ethereum/__init__.py
@@ -2,11 +2,15 @@ from trezor import wire
 from trezor.messages import MessageType
 
 from apps.common import HARDENED
+from apps.ethereum.networks import all_slip44_ids_hardened
 
 
 def boot():
-    ns = [["secp256k1", HARDENED | 44, HARDENED | 60]]
+    ns = []
+    for i in all_slip44_ids_hardened():
+        ns.append(["secp256k1", HARDENED | 44, i])
     wire.add(MessageType.EthereumGetAddress, __name__, "get_address", ns)
+    wire.add(MessageType.EthereumGetPublicKey, __name__, "get_public_key", ns)
     wire.add(MessageType.EthereumSignTx, __name__, "sign_tx", ns)
     wire.add(MessageType.EthereumSignMessage, __name__, "sign_message", ns)
     wire.add(MessageType.EthereumVerifyMessage, __name__, "verify_message")

--- a/src/apps/ethereum/address.py
+++ b/src/apps/ethereum/address.py
@@ -1,13 +1,34 @@
-from apps.common import HARDENED
+from apps.common import HARDENED, paths
+from apps.ethereum import networks
 
 
 """
-We believe Ethereum should use 44'/60'/a' for everything,because it is
+We believe Ethereum should use 44'/60'/a' for everything, because it is
 account-based, rather than UTXO-based. Unfortunately, lot of Ethereum
 tools (MEW, Metamask) do not use such scheme and set a = 0 and then
 iterate the address index i. Therefore for compatibility reasons we use
 the same scheme: 44'/60'/0'/0/i and only the i is being iterated.
 """
+
+
+def validate_path_for_get_public_key(path: list) -> bool:
+    """
+    This should be 44'/60'/0', but other non-hardened items are allowed.
+    """
+    length = len(path)
+    if length < 3 or length > 5:
+        return False
+    if path[0] != 44 | HARDENED:
+        return False
+    if path[1] not in networks.all_slip44_ids_hardened():
+        return False
+    if path[2] != 0 | HARDENED:
+        return False
+    if length > 3 and paths.is_hardened(path[3]):
+        return False
+    if length > 4 and paths.is_hardened(path[4]):
+        return False
+    return True
 
 
 def validate_full_path(path: list) -> bool:
@@ -19,7 +40,7 @@ def validate_full_path(path: list) -> bool:
         return False
     if path[0] != 44 | HARDENED:
         return False
-    if path[1] != 60 | HARDENED:
+    if path[1] not in networks.all_slip44_ids_hardened():
         return False
     if path[2] != 0 | HARDENED:
         return False

--- a/src/apps/ethereum/get_public_key.py
+++ b/src/apps/ethereum/get_public_key.py
@@ -1,0 +1,32 @@
+from trezor.messages.EthereumPublicKey import EthereumPublicKey
+from trezor.messages.HDNodeType import HDNodeType
+
+from apps.common import coins, layout, paths
+from apps.ethereum import address
+
+
+async def get_public_key(ctx, msg, keychain):
+    await paths.validate_path(
+        ctx, address.validate_path_for_get_public_key, path=msg.address_n
+    )
+    node = keychain.derive(msg.address_n)
+
+    # we use the Bitcoin format for Ethereum xpubs
+    btc = coins.by_name("Bitcoin")
+    node_xpub = node.serialize_public(btc.xpub_magic)
+
+    pubkey = node.public_key()
+    if pubkey[0] == 1:
+        pubkey = b"\x00" + pubkey[1:]
+    node_type = HDNodeType(
+        depth=node.depth(),
+        child_num=node.child_num(),
+        fingerprint=node.fingerprint(),
+        chain_code=node.chain_code(),
+        public_key=pubkey,
+    )
+
+    if msg.show_display:
+        await layout.show_pubkey(ctx, pubkey)
+
+    return EthereumPublicKey(node=node_type, xpub=node_xpub)

--- a/src/apps/ethereum/networks.py
+++ b/src/apps/ethereum/networks.py
@@ -1,6 +1,8 @@
 # generated from networks.py.mako
 # do not edit manually!
 
+from apps.common import HARDENED
+
 
 def shortcut_by_chain_id(chain_id, tx_type=None):
     if tx_type in [1, 6] and chain_id in [1, 3]:
@@ -22,6 +24,11 @@ def by_slip44(slip44):
         if n.slip44 == slip44:
             return n
     return None
+
+
+def all_slip44_ids_hardened():
+    for n in NETWORKS:
+        yield n.slip44 | HARDENED
 
 
 class NetworkInfo:

--- a/src/apps/ethereum/networks.py.mako
+++ b/src/apps/ethereum/networks.py.mako
@@ -1,6 +1,8 @@
 # generated from networks.py.mako
 # do not edit manually!
 
+from apps.common import HARDENED
+
 
 def shortcut_by_chain_id(chain_id, tx_type=None):
     if tx_type in [1, 6] and chain_id in [1, 3]:
@@ -22,6 +24,11 @@ def by_slip44(slip44):
         if n.slip44 == slip44:
             return n
     return None
+
+
+def all_slip44_ids_hardened():
+    for n in NETWORKS:
+        yield n.slip44 | HARDENED
 
 
 class NetworkInfo:

--- a/src/apps/wallet/sign_tx/addresses.py
+++ b/src/apps/wallet/sign_tx/addresses.py
@@ -261,7 +261,6 @@ def validate_purpose_against_script_type(
 def validate_path_for_bitcoin_public_key(path: list, coin: CoinInfo) -> bool:
     """
     Validates derivation path to fit Bitcoin-like coins for GetPublicKey.
-    Script type is omitted here because it is not usually sent.
     """
     length = len(path)
     if length < 3 or length > 5:

--- a/tests/test_apps.ethereum.address.py
+++ b/tests/test_apps.ethereum.address.py
@@ -1,7 +1,7 @@
 from common import *
 from apps.common.paths import HARDENED
 from apps.ethereum.address import ethereum_address_hex, validate_full_path
-from apps.ethereum.networks import NetworkInfo
+from apps.ethereum.networks import NetworkInfo, by_chain_id
 
 
 class TestEthereumGetAddress(unittest.TestCase):
@@ -62,11 +62,14 @@ class TestEthereumGetAddress(unittest.TestCase):
             [44 | HARDENED, 60 | HARDENED, 0 | HARDENED, 1, 0],
             [44 | HARDENED, 60 | HARDENED, 1 | HARDENED, 0, 0],
             [44 | HARDENED, 160 | HARDENED, 0 | HARDENED, 0, 0],
+            [44 | HARDENED, 199 | HARDENED, 0 | HARDENED, 0, 9999],  # slip44 not one of ETH chains
         ]
         correct_paths = [
             [44 | HARDENED, 60 | HARDENED, 0 | HARDENED, 0, 0],
             [44 | HARDENED, 60 | HARDENED, 0 | HARDENED, 0, 9],
             [44 | HARDENED, 60 | HARDENED, 0 | HARDENED, 0, 9999],
+            [44 | HARDENED, 6060 | HARDENED, 0 | HARDENED, 0, 0],
+            [44 | HARDENED, 1 | HARDENED, 0 | HARDENED, 0, 0],
         ]
 
         for path in incorrect_paths:


### PR DESCRIPTION
This PR adds GetPublicKey to ETH, but does not add validation checks for wallet's get public key.

Currently Frontend (Connect, Wallet etc.) uses Bitcoin's GetPublicKey for getting Ethereum's xpub. This a) is incosistent b) prohibits adding validation checks for Bitcoin's GetPublicKey, because the checks use the 'coin_name' field, which is meant for Bitcoin-like coins only.

EthereumGetPublicKey will not be used right away, but it is ready for future use on Frontend. It should replace the current usage of Bitcoin's GetPublicKey in Ethereum.

When Frontend is ready, the validation checks will be merged into core, as tracked in #406.
