### PR TITLE
docker: emulator support refacoring

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 # initialize from the image
 
-FROM debian:9
+ARG BASE_IMAGE=debian:9
+FROM ${BASE_IMAGE} AS base
 
 ARG TOOLCHAIN_FLAVOR=linux
 ENV TOOLCHAIN_FLAVOR=$TOOLCHAIN_FLAVOR

--- a/docker/emulator/Dockerfile
+++ b/docker/emulator/Dockerfile
@@ -1,15 +1,62 @@
-FROM python:3.7.1-stretch
+# initialize from the image
 
-WORKDIR /trezor-emulator
+ARG BASE_IMAGE=trezor-core:latest
+FROM ${BASE_IMAGE} AS tbuilder
 
-COPY ./ /trezor-emulator
-RUN make vendor
+RUN set -ex && \
+    apt-get update && \
+    apt-get --no-install-recommends --yes install \
+        build-essential \
+        git \
+        libusb-1.0-0 \
+        openssh-client \
+        pkg-config \
+        python3-dev \
+        python3-pip \
+        scons \
+        wget \
+    && pip3 install -U setuptools wheel \
+    && pip3 install scons trezor
 
-RUN apt-get update
-RUN apt-get install libusb-1.0-0
+# GUI additions
+ARG TREZOR_GUI=0
+ENV TREZOR_GUI=$TREZOR_GUI
+RUN set -ex && \
+    if [ "${TREZOR_GUI}" -eq 1 ]; then \
+            apt-get --no-install-recommends --yes install \
+                libsdl2-dev \
+                libsdl2-image-dev; \
+    fi
 
-RUN pip3 install scons trezor
-RUN make build_unix_noui
+# Packager cleanup, best practices
+RUN set -ex && rm -rf /var/lib/apt/lists/*
 
-ENTRYPOINT ["emulator/run.sh"]
-EXPOSE 21324/udp 21325
+FROM tbuilder AS temu0
+ENV PROJECT_DIR /usr/local/src/trezor-core
+
+WORKDIR $PROJECT_DIR
+COPY . $PROJECT_DIR/
+RUN set -ex && make vendor;
+
+FROM temu0 AS temu
+RUN set -ex \
+    && echo "Building GUI: ${TREZOR_GUI}" \
+    && if [ "${TREZOR_GUI}" -eq 1 ] ; then \
+        make build_unix; \
+        touch "built.gui"; \
+       else \
+        make build_unix_noui; \
+        touch "built.nogui"; \
+      fi;
+
+EXPOSE 21324/udp
+EXPOSE 21325/udp
+
+ARG PYOPT=0
+ENV PYOPT=$PYOPT
+ENV TREZOR_UDP_IP=0.0.0.0
+
+# In order to bypass entrypoint pass the folowing param
+# to the docker run command: --entrypoint bash
+ENTRYPOINT ["make", "emu"]
+

--- a/docker/emulator/README.md
+++ b/docker/emulator/README.md
@@ -1,0 +1,67 @@
+## Trezor-core Emulator in Docker
+
+You can run Trezor-core emulator with Docker:
+
+```bash
+git clone --recursive https://github.com/trezor/trezor-core.git
+cd trezor-core
+
+./docker/emulator/build.sh  # builds docker image (needed only once)
+./docker/emulator/run.sh    # runs docker image
+```
+
+This gives you simple emulator without GUI, exposing emulator UDP ports to the host so you can connect to it.
+The emulator shoult be listed by:
+
+```bash
+trezorctl list
+```
+
+
+### GUI support
+
+Alternativelly, you can build image with GUI support which requires X server. For OSX you can use [XQuartz](https://www.xquartz.org/).
+
+```bash
+TREZOR_GUI=1 ./docker/emulator/build.sh  # need to build GUI image
+TREZOR_GUI=1 ./docker/emulator/run.sh    # run with GUI (configures display)
+```
+
+
+### Base image
+
+Aforementioned images are built on top of Debian 9 image. If you rather prefer Ubuntu, change `BASE_IMAGE`:
+
+```bash
+BASE_IMAGE=ubuntu:18.04 ./docker/emulator/build.sh
+```
+
+
+### With toolchain
+
+The images are built on the base image without toolchain for compiling firmware to the Trezor hardware architecture.
+If you prefer to build emulator image with the toolchain:
+
+```bash
+WITH_TOOLCHAIN=1 ./docker/emulator/build.sh
+```
+
+Toolchain image is again based on Debian 9. This can be changed by setting `BASE_IMAGE` appropriately.
+
+
+### PYOPT
+
+Emulator runs by default with `PYOPT=0`, the debugging mode. This can be changed by:
+
+```bash
+PYOPT=1 ./docker/emulator/run.sh
+```
+
+
+### Bypassing entrypoint
+
+Trezor images run emulator directly. In order to bypass this and get the shell of the emulator container use:
+
+```bash
+./docker/emulator/run.sh --entrypoint bash
+```

--- a/docker/emulator/build.sh
+++ b/docker/emulator/build.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+cd "$(dirname "$0")"
+cd ../..
+
+TREZOR_GUI=${TREZOR_GUI:-0}
+BASE_IMAGE=${BASE_IMAGE:-}
+WITH_TOOLCHAIN=${WITH_TOOLCHAIN:-0}
+[[ "$TREZOR_GUI" -eq "1" ]] && TAG="trezor-emu-gui" || TAG="trezor-emu"
+
+echo "Trezor emulator image build, GUI support: $TREZOR_GUI, image name: $TAG"
+
+# Root image build if toolchain is required
+# Toolchain adds support for building hardware firmware
+if [ "${WITH_TOOLCHAIN}" -eq 1 ]; then
+    echo "Building base Trezor-core image"
+
+    BASE_IMAGE_ARG=""
+    if [ -n "$BASE_IMAGE" ]; then
+        BASE_IMAGE_ARG="--build-arg BASE_IMAGE=${BASE_IMAGE}"
+    fi
+
+    docker build $BASE_IMAGE_ARG -t="trezor-core" .
+    BASE_IMAGE="trezor-core:latest"
+
+else
+    BASE_IMAGE=${BASE_IMAGE:-debian:9}
+
+fi
+
+# emu image build
+echo "Building Trezor-core emulator image"
+docker build -f docker/emulator/Dockerfile --build-arg BASE_IMAGE=$BASE_IMAGE --build-arg TREZOR_GUI=$TREZOR_GUI -t="$TAG" $@ .
+
+echo "Docker image $TAG built"

--- a/docker/emulator/run.sh
+++ b/docker/emulator/run.sh
@@ -1,7 +1,41 @@
 #!/bin/bash
 cd "$(dirname "$0")"
-cd ..
+cd ../..
 
-export TREZOR_UDP_IP=0.0.0.0
+PYOPT=${PYOPT:-0}
+TREZOR_GUI=${TREZOR_GUI:-0}
 
-source emu.sh
+if [[ "$TREZOR_GUI" -eq "1" ]]; then
+    TAG="trezor-emu-gui"
+
+    # Quartz start, permissions
+    xhost + 127.0.0.1 >/dev/null
+
+    # Get display number if not defined
+    if [ -z "${DISPLAY_NUMBER}" ]; then
+        OPERATING_SYSTEM=$(uname)
+        if [ $OPERATING_SYSTEM == "Darwin" ]; then
+            DISPLAY_NUMBER=`ps -ef | grep "Xquartz :\d" | grep -v xinit | awk '{ print $9; }'`
+        else
+            DISPLAY_NUMBER=`echo $DISPLAY | awk '{ n=split($0, a, ":"); print ":"a[n]; }'`
+        fi
+    fi
+
+    DARGS=("--env=DISPLAY=host.docker.internal${DISPLAY_NUMBER}" \
+          "--env=XAUTHORITY" \
+          "--volume="$HOME/.Xauthority:/root/.Xauthority:rw"" \
+          "-v /tmp/.X11-unix:/tmp/.X11-unix")
+
+    echo "Starting Trezor-Emu docker with GUI, display number $DISPLAY_NUMBER"
+else
+    TAG="trezor-emu"
+    DARGS=()
+    echo "Starting Trezor-Emu docker"
+fi
+
+docker run -i  \
+    -p 21324:21324/udp \
+    -p 21325:21325/udp \
+    -e PYOPT=$PYOPT \
+    ${DARGS[@]} $@ \
+    -t $TAG:latest

--- a/docs/emulator.md
+++ b/docs/emulator.md
@@ -25,3 +25,10 @@ TREZOR_PROFILE=/var/tmp/foobar ./emu.sh
 ```
 
 When the **TREZOR_PROFILE** is not set the default is ```/var/tmp``` .
+
+
+## Docker instance
+
+If you need Trezor emulator just as a service without need to setup the build environment you can make use of a docker.
+
+Read more on [emulator in docker](../docker/emulator/README.md)


### PR DESCRIPTION
I was playing with the Trezor emulator support in docker a bit. I had some issues with the original Dockerfile (I needed also GUI) so I created a slightly modified version. 

Dockerized Trezor-core emulator is beneficial also to other integrating projects, e.g., I could make use of it in Monero CI: https://github.com/monero-project/monero/pull/4977

In the simplest version, the emulator runs without GUI, minimal setup for integration testing of the integration. The idea is to clone a trezor-core branch, build the docker image and run it. 

We could also upload master firmware releases to the Docker repository (testing against released versions).

It is also possible to build and run with GUI. It was tested on OSX, should work on Linux too, potentially also on Windows with an appropriate X server.

All options are in [docker/emulator/README.md](https://github.com/trezor/trezor-core/blob/646d75c7edd8ef6b63886eb79825ff48f9495c01/docker/emulator/README.md)

Give it a thought, if this is OK for you. 

Thanks