### PR TITLE
u2f: "u2f.bin.coffee checker" -> "u2f.bin.coffee"

### DIFF
--- a/src/apps/fido_u2f/knownapps.py
+++ b/src/apps/fido_u2f/knownapps.py
@@ -14,7 +14,7 @@ knownapps = {
     hashlib.sha256(
         b"https://slushpool.com/static/security/u2f.json"
     ).digest(): "Slush Pool",
-    hashlib.sha256(b"https://u2f.bin.coffee").digest(): "u2f.bin.coffee checker",
+    hashlib.sha256(b"https://u2f.bin.coffee").digest(): "u2f.bin.coffee",
     hashlib.sha256(b"https://vault.bitwarden.com/app-id.json").digest(): "bitwarden",
     hashlib.sha256(b"https://www.bitfinex.com").digest(): "Bitfinex",
     hashlib.sha256(b"https://www.dropbox.com/u2f-app-id.json").digest(): "Dropbox",


### PR DESCRIPTION
Trezor Model T can display 20 chars max, which causes this name to display as "2f.bin.coffee checke".