### PR TITLE
Skip identical screenshots in display.save

### DIFF
--- a/embed/extmod/modtrezorui/display-stm32_1.h
+++ b/embed/extmod/modtrezorui/display-stm32_1.h
@@ -241,4 +241,6 @@ void display_refresh(void) {
   HAL_GPIO_WritePin(OLED_DC_PORT, OLED_DC_PIN, GPIO_PIN_RESET);  // set to CMD
 }
 
-void display_save(const char *prefix) {}
+const char *display_save(const char *prefix) {
+  return NULL;
+}

--- a/embed/extmod/modtrezorui/display-stm32_t.h
+++ b/embed/extmod/modtrezorui/display-stm32_t.h
@@ -498,4 +498,6 @@ void display_refresh(void) {
   }
 }
 
-void display_save(const char *prefix) {}
+const char *display_save(const char *prefix) {
+  return NULL;
+}

--- a/embed/extmod/modtrezorui/display-unix.h
+++ b/embed/extmod/modtrezorui/display-unix.h
@@ -206,23 +206,34 @@ static void display_set_orientation(int degrees) { display_refresh(); }
 
 static void display_set_backlight(int val) { display_refresh(); }
 
-void display_save(const char *prefix) {
+const char *display_save(const char *prefix) {
 #ifndef TREZOR_EMULATOR_NOUI
   if (!RENDERER) {
     display_init();
   }
-  static uint32_t cnt = 0;
-  char fname[256];
-  snprintf(fname, sizeof(fname), "%s%08d.png", prefix, cnt);
+  static int count;
+  static char filename[256];
+  static SDL_Surface *prev;
+  // take a cropped view of the screen contents
   const SDL_Rect rect = {0, 0, DISPLAY_RESX, DISPLAY_RESY};
   SDL_Surface *crop = SDL_CreateRGBSurface(
       BUFFER->flags, rect.w, rect.h, BUFFER->format->BitsPerPixel,
       BUFFER->format->Rmask, BUFFER->format->Gmask, BUFFER->format->Bmask,
       BUFFER->format->Amask);
   SDL_BlitSurface(BUFFER, &rect, crop, NULL);
-  IMG_SavePNG(crop, fname);
-  SDL_FreeSurface(crop);
-  fprintf(stderr, "Saved screenshot to %s\n", fname);
-  cnt++;
+  // compare with previous screen, skip if equal
+  if (prev != NULL) {
+    if (memcmp(prev->pixels, crop->pixels, crop->pitch * crop->h) == 0) {
+      SDL_FreeSurface(crop);
+      return filename;
+    }
+    SDL_FreeSurface(prev);
+  }
+  // save to png
+  snprintf(filename, sizeof(filename), "%s%08d.png", prefix, count++);
+  IMG_SavePNG(crop, filename);
+  prev = crop;
+  return filename;
 #endif
+  return NULL;
 }

--- a/embed/extmod/modtrezorui/display.h
+++ b/embed/extmod/modtrezorui/display.h
@@ -67,7 +67,7 @@
 
 void display_init(void);
 void display_refresh(void);
-void display_save(const char *prefix);
+const char *display_save(const char *prefix);
 
 // provided by common
 

--- a/embed/unix/touch.c
+++ b/embed/unix/touch.c
@@ -28,7 +28,7 @@ extern int sdl_display_res_x, sdl_display_res_y;
 extern int sdl_touch_offset_x, sdl_touch_offset_y;
 
 extern void __shutdown(void);
-extern void display_save(const char *prefix);
+extern const char *display_save(const char *prefix);
 
 uint32_t touch_read(void) {
 #ifndef TREZOR_EMULATOR_NOUI


### PR DESCRIPTION
Base of architecture for UI tests and workflow documentation.