### PR TITLE
Save screen after every refresh

### DIFF
--- a/SConscript.unix
+++ b/SConscript.unix
@@ -127,6 +127,7 @@ SOURCE_MICROPYTHON = [
     'vendor/micropython/extmod/modutimeq.c',
     'vendor/micropython/extmod/utime_mphal.c',
     'vendor/micropython/lib/mp-readline/readline.c',
+    'vendor/micropython/ports/unix/modos.c',
     'vendor/micropython/py/argcheck.c',
     'vendor/micropython/py/asmarm.c',
     'vendor/micropython/py/asmbase.c',

--- a/embed/unix/mpconfigport.h
+++ b/embed/unix/mpconfigport.h
@@ -177,7 +177,7 @@ extern const struct _mp_print_t mp_stderr_print;
 #define MICROPY_ASYNC_KBD_INTR (1)
 
 // extern const struct _mp_obj_module_t mp_module_machine;
-// extern const struct _mp_obj_module_t mp_module_os;
+extern const struct _mp_obj_module_t mp_module_os;
 // extern const struct _mp_obj_module_t mp_module_uos_vfs;
 // extern const struct _mp_obj_module_t mp_module_uselect;
 extern const struct _mp_obj_module_t mp_module_time;
@@ -272,7 +272,7 @@ extern const struct _mp_obj_module_t mp_module_trezorutils;
   MICROPY_PY_UTIME_DEF                                                     \
   MICROPY_PY_SOCKET_DEF                                                    \
   /* { MP_ROM_QSTR(MP_QSTR_umachine), MP_ROM_PTR(&mp_module_machine) }, */ \
-  /* { MP_ROM_QSTR(MP_QSTR_uos), MP_ROM_PTR(&mp_module_os) }, */           \
+  { MP_ROM_QSTR(MP_QSTR_uos), MP_ROM_PTR(&mp_module_os) },                 \
   MICROPY_PY_UOS_VFS_DEF                                                   \
   MICROPY_PY_USELECT_DEF                                                   \
   MICROPY_PY_TERMIOS_DEF                                                   \

--- a/src/trezor/ui/__init__.py
+++ b/src/trezor/ui/__init__.py
@@ -13,6 +13,8 @@ if __debug__:
     def debug_display_refresh():
         display.bar(Display.WIDTH - 8, 0, 8, 8, 0xF800)
         display.refresh()
+        if utils.SAVE_SCREEN:
+            display.save("refresh")
 
     loop.after_step_hook = debug_display_refresh
 

--- a/src/trezor/utils.py
+++ b/src/trezor/utils.py
@@ -13,6 +13,16 @@ from trezorutils import (  # noqa: F401
     set_mode_unprivileged,
 )
 
+if __debug__:
+    if EMULATOR:
+        import uos
+
+        TEST = int(uos.getenv("TREZOR_TEST") or "0")
+        SAVE_SCREEN = int(uos.getenv("TREZOR_SAVE_SCREEN") or "0")
+    else:
+        TEST = 0
+        SAVE_SCREEN = 0
+
 
 def unimport_begin():
     return set(sys.modules)


### PR DESCRIPTION
If environment variable `TREZOR_SAVE_SCREEN` is set, every screen refresh produces a screenshot in current directory. Useful for integration testing and generating workflow documentation.