### PR TITLE
xmr: live refresh progress starts from 0

### DIFF
--- a/src/apps/monero/live_refresh.py
+++ b/src/apps/monero/live_refresh.py
@@ -37,7 +37,7 @@ async def live_refresh(ctx, msg: MoneroLiveRefreshStartRequest, keychain):
 
 class LiveRefreshState:
     def __init__(self):
-        self.current_output = -1
+        self.current_output = 0
         self.creds = None
 
 


### PR DESCRIPTION
Minor fix on live refresh progress monitoring, it started from -1 before.